### PR TITLE
Change example for one that outputs plain text response

### DIFF
--- a/docs/chatbot/variables/customapi.md
+++ b/docs/chatbot/variables/customapi.md
@@ -13,11 +13,11 @@ This variable does not take any parameters.
 #### Example Input
 
 ```
-$(customapi.https://api.chucknorris.io/jokes/random)
+$(customapi.https://decapi.me/youtube/latest_video?id=UCjerlCIbLPQwSnYlClkjDXg)
 ```
 
 #### Example Output
 
 ```
-Chuck Norris brushes his teeth with a mixture of iron shavings, industrial paint remover, and wood-grain alcohol.
+STREAMELEMENTS PATCH NOTES - SEPTEMBER 10, 2023 #streamelements #updates #patchnotes - https://youtu.be/-q_q37PoaM8
 ```


### PR DESCRIPTION
Current API endpoint example does not provide a plain text response, but a JSON output, which can create some confusion to the users.  Changed it to an actual example that returns a plain text response.