### PR TITLE
Added time zone example for time.until

### DIFF
--- a/docs/chatbot/variables/time.md
+++ b/docs/chatbot/variables/time.md
@@ -13,7 +13,7 @@ Displays the time in the given timezone. A list can be found here [Timezones](ht
 
 #### Parameters
 
-This variable accepts a timezone as input. If no timezone is provided the variable will error.
+This variable accepts a timezone as input. If no timezone is provided the variable will return UTC time. In case timezone is unknown, the variable will error.
 
 #### Example Input
 
@@ -39,16 +39,24 @@ Displays a countdown until an inputted UTC timestamp.
 
 #### Parameters
 
-This variable accepts a timezone as input. If no timezone is provided the variable will error.
+This variable accepts a timezone as input in format [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601). If no timezone is provided, the variable returns UTC time. In the format is wrong, the variable will error.
 
 #### Example Input
 
 ```
 next stream in ${time.until 19:00}
+next stream in ${time.until 2024-06-20T19:00:00-03:00}
 ```
 
 #### Example Output
 
 ```
 next stream in 7 hours 59 mins
+next stream in 1 day 11 hours 
+```
+
+#### Example Error
+
+```
+parsing time "19:00:00-03:00" as "2006-01-02T15:04:05Z07:00": cannot parse "19:00:00-03:00" as "2006"
 ```


### PR DESCRIPTION
- Added explanation when will error or default to UTC for both `time` and `time.until` variables. 
- Added example on how to provide time zone for time.until. 

Closes #21 
