### PR TITLE
Link Filter delete message option clarified

### DIFF
--- a/docs/chatbot/filters/links.md
+++ b/docs/chatbot/filters/links.md
@@ -21,7 +21,7 @@ The Link filter helps manage the posting of links in chat messages. It checks if
 
 ### Supported Settings
 
-- `Timeout duration`: This is the duration (in seconds) for which a user will be timed out if their message violates the link rules.
+- `Timeout duration`: This is the duration (in seconds) for which a user will be timed out if their message violates the link rules. Setting to 0 will just delete the message.
 - `Excluded user groups`: These are the user groups that are exempt from the link filter. Messages from users in these groups will not be checked by the filter.
 - `Custom timeout message`: This is the message that will be displayed when a user is timed out due to a violation of the link rules. This message can be customized to provide specific information about the violation and the timeout.
 - `Allowlist`: This is a list of links or link patterns that are allowed in messages. The filter supports wildcard characters in this list, allowing for flexible rules.


### PR DESCRIPTION
Documented the feature where if timeout is set to 0, the bot will delete the message and not timeout the user.