### PR TITLE
Fix broken links

### DIFF
--- a/docs/chatbot/commands/custom/index.md
+++ b/docs/chatbot/commands/custom/index.md
@@ -115,7 +115,7 @@ Bot: The stream has been live for 2 days 5 hours. We're currently playing Fortni
 
 Variables used:
 
-- [$(uptime)](../../variables/channel.md#uptime) - The time the stream has been live
+- [$(uptime)](../../variables/channel.md#channeluptime) - The time the stream has been live
 - [$(channel.game)](../../variables/channel.md#channelgame) - The game the stream is currently playing
 - [$(channel.viewers)](../../variables/channel.md#channelviewers) - The number of viewers currently watching the stream
 
@@ -136,7 +136,7 @@ Bot: Styler, weather in: Aarhus, Denmark: 🌜 17.7 °C (63.9 °F). Feels like 1
 
 Variables used:
 
-- [$(weather)](../../variables/weather.md#weather) - The current weather in a specified location
+- [$(weather)](../../variables/weather.md) - The current weather in a specified location
 
 ### Shoutout Command
 

--- a/docs/overlays/widget-structure.md
+++ b/docs/overlays/widget-structure.md
@@ -38,7 +38,7 @@ Adding an invalid type will default it to `"type":"text"`.
 There are some reserved field names (all future reserved words will start with `widget`):
 * `widgetName` - Used to set the display name of the widget
 * `widgetAuthor` - Set the author name of the widget (adds a "(by Author)" to the widget name)
-* `widgetDuration` - maximum event queue hold time (seconds) - for Custom Widget (as alertboxes have their own timers). Explained in [resumeQueue section](#resumequeue-method-and-widgetduration-property) below
+* `widgetDuration` - maximum event queue hold time (seconds) - for Custom Widget (as alertboxes have their own timers). Explained in [resumeQueue section](custom-widget.md#resumequeue-method-and-widgetduration-property)
 ### Example
 #### JSON
 ```JSON


### PR DESCRIPTION
Fix the following broken links in Custom Commands page
- linking to /chatbot/variables/channel#uptime -> /chatbot/variables/channel#channeluptime
- linking to /chatbot/variables/weather#weather -> /chatbot/variables/weather