### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -44,7 +44,7 @@ const config: Config = {
 
   themes: ['@docusaurus/theme-mermaid'],
 
-  plugins: [],
+  plugins: ['docusaurus-plugin-copy-page-button'],
 
   presets: [
     [

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@docusaurus/theme-mermaid": "^3.9.2",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@docusaurus/theme-mermaid": "^3.9.2",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
-    "docusaurus-plugin-copy-page-button": "^0.4.2",
+    "docusaurus-plugin-copy-page-button": "^0.5.2",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current StreamElements docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for StreamElements

A huge fraction of StreamElements users are streamers wiring up custom commands, chatbot variables, and overlay logic. Most of them are not full-time developers, so they lean heavily on AI assistants to translate "I want a !so command that pulls the last game played from Twitch API" into actual chatbot syntax. A one-click "open this docs page in ChatGPT" handoff would shorten that loop a lot.

The plugin auto-injects into the table-of-contents sidebar, no further config needed.

## Production users

The plugin is currently shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, Cardano, Kurtosis, and Dagger docs. ~10k npm installs/month.

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `dependencies`
- Adds the plugin string to the `plugins` array in `docusaurus.config.ts` (it was an empty array)

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.