### PR TITLE
Drop trailing slashes from all URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -59,6 +59,12 @@ function emitRedirectsFile() {
 export default defineConfig({
   site: 'https://docs.streamelements.com',
 
+  // URLs have no trailing slash (parity with the old Docusaurus site, so
+  // inbound links and search results resolve without a 301 hop). Output stays
+  // in directory format (/path/index.html); Cloudflare serves /path from it
+  // via html_handling: 'drop-trailing-slash' in wrangler.jsonc.
+  trailingSlash: 'never',
+
   redirects,
 
   integrations: [
@@ -108,14 +114,14 @@ export default defineConfig({
         starlightLinksValidator({
           errorOnLocalLinks: false,
           // Changelog routes are custom pages the validator can't see.
-          exclude: ['/changelog/', '/changelog/**'],
+          exclude: ['/changelog', '/changelog/**'],
         }),
         starlightLlmsTxt(),
         starlightSidebarTopics(
           [
             {
               label: 'Chatbot',
-              link: '/chatbot/',
+              link: '/chatbot',
               icon: 'comment',
               items: [
                 { label: 'Overview', slug: 'chatbot' },
@@ -143,7 +149,7 @@ export default defineConfig({
             },
             {
               label: 'Overlays',
-              link: '/overlays/',
+              link: '/overlays',
               icon: 'desktop',
               items: [
                 { label: 'Overview', slug: 'overlays' },
@@ -168,7 +174,7 @@ export default defineConfig({
             },
             {
               label: 'WebSockets',
-              link: '/websockets/',
+              link: '/websockets',
               icon: 'server',
               items: [
                 { label: 'Introduction', slug: 'websockets' },
@@ -227,7 +233,7 @@ export default defineConfig({
             },
             {
               label: 'Changelog',
-              link: '/changelog/',
+              link: '/changelog',
               icon: 'rocket',
             },
           ],

--- a/src/components/changelog/ChangelogList.astro
+++ b/src/components/changelog/ChangelogList.astro
@@ -27,7 +27,7 @@ const rendered = await Promise.all(
         </div>
         <div class="changelog-body">
           <h2 class="changelog-title">
-            <a href={`/changelog/post/${entry.slug}/`}>{entry.data.title}</a>
+            <a href={`/changelog/post/${entry.slug}`}>{entry.data.title}</a>
           </h2>
           <ProductPills products={entry.data.products} />
           <div class="changelog-content sl-markdown-content">

--- a/src/components/changelog/ChangelogPagination.astro
+++ b/src/components/changelog/ChangelogPagination.astro
@@ -15,7 +15,7 @@ interface Props {
 const { page, baseUrl } = Astro.props;
 
 function pageUrl(n: number): string {
-  return n === 1 ? baseUrl : `${baseUrl}${n}/`;
+  return n === 1 ? baseUrl : `${baseUrl}/${n}`;
 }
 
 const numbers: Array<number | null> = [];

--- a/src/components/changelog/ProductFilter.astro
+++ b/src/components/changelog/ProductFilter.astro
@@ -17,10 +17,10 @@ const activeIds = await getActiveProductIds();
 <label class="product-filter">
   <span>Product:</span>
   <select data-changelog-filter>
-    <option value="/changelog/" selected={!current}>All products</option>
+    <option value="/changelog" selected={!current}>All products</option>
     {
       activeIds.map((id) => (
-        <option value={`/changelog/product/${id}/`} selected={current === id}>
+        <option value={`/changelog/product/${id}`} selected={current === id}>
           {PRODUCTS[id].name}
         </option>
       ))

--- a/src/content/changelog/chatbot/2024-07-29-link-filter-fix.mdx
+++ b/src/content/changelog/chatbot/2024-07-29-link-filter-fix.mdx
@@ -4,4 +4,4 @@ description: Fixed an issue where the Link Protection filter could flag emote co
 date: 2024-07-29
 ---
 
-Fixed an issue with [Link Protection](/chatbot/filters/links/) which could flag emote combinations as links on YouTube.
+Fixed an issue with [Link Protection](/chatbot/filters/links) which could flag emote combinations as links on YouTube.

--- a/src/content/changelog/chatbot/2024-08-08-tft-variable-and-fixes.mdx
+++ b/src/content/changelog/chatbot/2024-08-08-tft-variable-and-fixes.mdx
@@ -4,6 +4,6 @@ description: Added the $(teamfighttactics) variable and fixed Viewer Queue comma
 date: 2024-08-08
 ---
 
-Added a new variable: [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics/).
+Added a new variable: [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics).
 
-Also fixed an issue which caused some [Viewer Queue](/chatbot/modules/viewerqueue/) commands to send multiple responses.
+Also fixed an issue which caused some [Viewer Queue](/chatbot/modules/viewerqueue) commands to send multiple responses.

--- a/src/content/changelog/docs/2024-07-24-chatbot-docs-overhaul.mdx
+++ b/src/content/changelog/docs/2024-07-24-chatbot-docs-overhaul.mdx
@@ -7,6 +7,6 @@ products: [chatbot]
 
 We gave the Chatbot documentation a comprehensive update for clarity and accuracy:
 
-- Updated all [default commands](/chatbot/commands/default/) and [variables](/chatbot/variables/) documentation
-- Enhanced the [`$(channel)`](/chatbot/variables/channel/) docs, including previously missing arguments
-- Improved the [`$(user)`](/chatbot/variables/user/) and [`$(sender)`](/chatbot/variables/sender/) variable docs
+- Updated all [default commands](/chatbot/commands/default) and [variables](/chatbot/variables) documentation
+- Enhanced the [`$(channel)`](/chatbot/variables/channel) docs, including previously missing arguments
+- Improved the [`$(user)`](/chatbot/variables/user) and [`$(sender)`](/chatbot/variables/sender) variable docs

--- a/src/content/changelog/websockets/2026-03-17-overlay-broadcast-topic.mdx
+++ b/src/content/changelog/websockets/2026-03-17-overlay-broadcast-topic.mdx
@@ -4,6 +4,6 @@ description: Broadcast custom events to your channel's overlays in real time, gl
 date: 2026-03-17
 ---
 
-The new [`channel.overlay.broadcast`](/websockets/topics/channel-overlay-broadcast/) topic delivers custom events to a channel's overlays in real time. Events can target all overlays globally or a specific overlay by ID.
+The new [`channel.overlay.broadcast`](/websockets/topics/channel-overlay-broadcast) topic delivers custom events to a channel's overlays in real time. Events can target all overlays globally or a specific overlay by ID.
 
 Each event carries a custom event name (max 256 characters) and a custom payload of up to 5KB.

--- a/src/content/changelog/websockets/2026-03-20-astro-protocol-docs.mdx
+++ b/src/content/changelog/websockets/2026-03-20-astro-protocol-docs.mdx
@@ -5,6 +5,6 @@ date: 2026-03-20
 products: [docs]
 ---
 
-The [WebSocket documentation](/websockets/) has been overhauled to match the protocol spec of Astro, StreamElements' dedicated pubsub websocket gateway.
+The [WebSocket documentation](/websockets) has been overhauled to match the protocol spec of Astro, StreamElements' dedicated pubsub websocket gateway.
 
 The docs now cover the full connection lifecycle — the welcome message on connect, the server-side heartbeat (PING frames every 30 seconds, with a 70-second pong timeout), reconnect tokens for resuming after a graceful shutdown, and the error codes returned when the server is draining or the connection rate limit is exceeded.

--- a/src/content/docs/chatbot/commands/custom.md
+++ b/src/content/docs/chatbot/commands/custom.md
@@ -1,10 +1,10 @@
 ---
 title: Custom Commands
 prev:
-  link: /chatbot/commands/
+  link: /chatbot/commands
   label: Commands overview
 next:
-  link: /chatbot/commands/default/
+  link: /chatbot/commands/default
   label: Default commands
 description: "Create and manage custom StreamElements Chatbot commands from the dashboard or directly in chat, with example commands using variables."
 keywords:
@@ -29,11 +29,11 @@ In addition to the default commands, you can also create your own custom command
 There are two ways to manage custom commands:
 
 1. Through the creator dashboard
-2. Directly in chat with the [!command](/chatbot/commands/default/command/) command
+2. Directly in chat with the [!command](/chatbot/commands/default/command) command
 
 ### Using the dashboard
 
-See [Getting Started](/chatbot/getting-started/) for a step-by-step walkthrough of creating a command in the dashboard.
+See [Getting Started](/chatbot/getting-started) for a step-by-step walkthrough of creating a command in the dashboard.
 
 ### Using chat
 
@@ -49,7 +49,7 @@ See [Getting Started](/chatbot/getting-started/) for a step-by-step walkthrough 
 `!command` is aliased as `!cmd`, so `!cmd add !socials ...` works the same way.
 :::
 
-For the full subcommand reference, including all available options, permissions, and aliases, read the documentation for the [!command](/chatbot/commands/default/command/) command.
+For the full subcommand reference, including all available options, permissions, and aliases, read the documentation for the [!command](/chatbot/commands/default/command) command.
 
 ## Examples
 
@@ -70,8 +70,8 @@ Bot: Viewer123, welcome to the stream! You last visited 2 days 5 hours ago.
 
 Variables used:
 
-- [$(user)](/chatbot/variables/user/#available-variables) - The name of the viewer
-- [$(user.lastseen)](/chatbot/variables/user/#available-variables) - The time the viewer last visited the stream
+- [$(user)](/chatbot/variables/user#available-variables) - The name of the viewer
+- [$(user.lastseen)](/chatbot/variables/user#available-variables) - The time the viewer last visited the stream
 
 ### Stream Uptime Command
 
@@ -90,9 +90,9 @@ Bot: The stream has been live for 2 days 5 hours. We're currently playing Fortni
 
 Variables used:
 
-- [$(uptime)](/chatbot/variables/uptime/) - The time the stream has been live
-- [$(channel.game)](/chatbot/variables/channel/#available-variables) - The game the stream is currently playing
-- [$(channel.viewers)](/chatbot/variables/channel/#available-variables) - The number of viewers currently watching the stream
+- [$(uptime)](/chatbot/variables/uptime) - The time the stream has been live
+- [$(channel.game)](/chatbot/variables/channel#available-variables) - The game the stream is currently playing
+- [$(channel.viewers)](/chatbot/variables/channel#available-variables) - The number of viewers currently watching the stream
 
 ### Weather Command
 
@@ -111,9 +111,9 @@ Bot: Viewer123, weather in: Tokyo, Japan: 🌜 17.7 °C (63.9 °F). Feels like 1
 
 Variables used:
 
-- [$(sender)](/chatbot/variables/sender/) - The viewer who triggered the command
-- [${1:}](/chatbot/variables/args/) - The arguments passed to the command, here the location to look up
-- [$(weather)](/chatbot/variables/weather/) - The current weather in a specified location
+- [$(sender)](/chatbot/variables/sender) - The viewer who triggered the command
+- [${1:}](/chatbot/variables/args) - The arguments passed to the command, here the location to look up
+- [$(weather)](/chatbot/variables/weather) - The current weather in a specified location
 
 ### Shoutout Command
 
@@ -132,5 +132,5 @@ Bot: Check out Styler, they are playing Counter-Strike at https://twitch.tv/Styl
 
 Variables used:
 
-- [${1}](/chatbot/variables/args/) - The first argument passed to the command, here the name of the user to shout out
-- [$(game)](/chatbot/variables/game/) - The game the user is currently playing
+- [${1}](/chatbot/variables/args) - The first argument passed to the command, here the name of the user to shout out
+- [$(game)](/chatbot/variables/game) - The game the user is currently playing

--- a/src/content/docs/chatbot/commands/default/8ball.mdx
+++ b/src/content/docs/chatbot/commands/default/8ball.mdx
@@ -54,5 +54,5 @@ The following aliases can be used interchangeably with `!8ball`:
 
 ## Related Commands
 
-*   [`!roulette`](/chatbot/commands/default/roulette/): Gamble loyalty points for a chance to win or lose.
-*   [`!slots`](/chatbot/commands/default/slots/): Play a slot machine game with loyalty points.
+*   [`!roulette`](/chatbot/commands/default/roulette): Gamble loyalty points for a chance to win or lose.
+*   [`!slots`](/chatbot/commands/default/slots): Play a slot machine game with loyalty points.

--- a/src/content/docs/chatbot/commands/default/accept.mdx
+++ b/src/content/docs/chatbot/commands/default/accept.mdx
@@ -12,7 +12,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!accept` command allows users to accept pending duel requests initiated by the [`!duel`](/chatbot/commands/default/duel/) command. A duel request must be accepted within **2 minutes**, otherwise it expires. Once accepted, the duel resolves immediately: the winner is decided by a 50/50 coin flip, gaining the wagered points while the loser loses them.
+The `!accept` command allows users to accept pending duel requests initiated by the [`!duel`](/chatbot/commands/default/duel) command. A duel request must be accepted within **2 minutes**, otherwise it expires. Once accepted, the duel resolves immediately: the winner is decided by a 50/50 coin flip, gaining the wagered points while the loser loses them.
 
 ## Usage
 
@@ -57,6 +57,6 @@ The `!accept` command is part of the **Duel module**. This module must be enable
 
 ## Related Commands
 
-*   [`!duel`](/chatbot/commands/default/duel/): Initiate a duel with another user.
-*   [`!cancelduel`](/chatbot/commands/default/cancelduel/): Cancel an outgoing duel request.
-*   [`!deny`](/chatbot/commands/default/deny/): Deny an incoming duel request.
+*   [`!duel`](/chatbot/commands/default/duel): Initiate a duel with another user.
+*   [`!cancelduel`](/chatbot/commands/default/cancelduel): Cancel an outgoing duel request.
+*   [`!deny`](/chatbot/commands/default/deny): Deny an incoming duel request.

--- a/src/content/docs/chatbot/commands/default/accountage.mdx
+++ b/src/content/docs/chatbot/commands/default/accountage.mdx
@@ -55,4 +55,4 @@ These aliases can be used interchangeably with the main command.
 
 ## Related Commands
 
-*   [`!followage`](/chatbot/commands/default/followage/): Checks how long a user has been following the channel.
+*   [`!followage`](/chatbot/commands/default/followage): Checks how long a user has been following the channel.

--- a/src/content/docs/chatbot/commands/default/addpoints.mdx
+++ b/src/content/docs/chatbot/commands/default/addpoints.mdx
@@ -58,6 +58,6 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!setpoints`](/chatbot/commands/default/setpoints/): Set a user's points to a specific value.
-*   [`!givepoints`](/chatbot/commands/default/givepoints/): Allow users to give points to each other.
-*   [`!points`](/chatbot/commands/default/points/): Check a user's current point balance.
+*   [`!setpoints`](/chatbot/commands/default/setpoints): Set a user's points to a specific value.
+*   [`!givepoints`](/chatbot/commands/default/givepoints): Allow users to give points to each other.
+*   [`!points`](/chatbot/commands/default/points): Check a user's current point balance.

--- a/src/content/docs/chatbot/commands/default/alerts.mdx
+++ b/src/content/docs/chatbot/commands/default/alerts.mdx
@@ -66,4 +66,4 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [Chat Alerts module](/chatbot/modules/chatalerts/): Sends automated chat messages for stream events such as follows, subscriptions, and raids.
+*   [Chat Alerts module](/chatbot/modules/chatalerts): Sends automated chat messages for stream events such as follows, subscriptions, and raids.

--- a/src/content/docs/chatbot/commands/default/bet.mdx
+++ b/src/content/docs/chatbot/commands/default/bet.mdx
@@ -15,7 +15,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!bet` command allows viewers to use their loyalty points to bet on the outcome of a contest or event defined by the streamer. This command is used **while a bet is active**, which is initiated through the StreamElements Dashboard. Viewers can check the active contest with [`!contest`](/chatbot/commands/default/contest/).
+The `!bet` command allows viewers to use their loyalty points to bet on the outcome of a contest or event defined by the streamer. This command is used **while a bet is active**, which is initiated through the StreamElements Dashboard. Viewers can check the active contest with [`!contest`](/chatbot/commands/default/contest).
 
 ## Usage
 
@@ -54,5 +54,5 @@ To place a bet while a betting contest is open, viewers use the following syntax
 
 ## Related Commands
 
-*   [`!contest`](/chatbot/commands/default/contest/): Checks the status and details of the currently active betting contest.
-*   [`!points`](/chatbot/commands/default/points/): Checks a user's current loyalty point balance.
+*   [`!contest`](/chatbot/commands/default/contest): Checks the status and details of the currently active betting contest.
+*   [`!points`](/chatbot/commands/default/points): Checks a user's current loyalty point balance.

--- a/src/content/docs/chatbot/commands/default/bingo.mdx
+++ b/src/content/docs/chatbot/commands/default/bingo.mdx
@@ -66,5 +66,5 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!points`](/chatbot/commands/default/points/): Check a user's current loyalty points balance.
-*   [`!top`](/chatbot/commands/default/top/): See the leaderboard for points or watch time.
+*   [`!points`](/chatbot/commands/default/points): Check a user's current loyalty points balance.
+*   [`!top`](/chatbot/commands/default/top): See the leaderboard for points or watch time.

--- a/src/content/docs/chatbot/commands/default/bot.mdx
+++ b/src/content/docs/chatbot/commands/default/bot.mdx
@@ -80,9 +80,9 @@ Makes the bot leave the chat channel entirely. The bot will need to be invited b
 
 ## Related Commands
 
-*   [`!commands`](/chatbot/commands/default/commands/): Lists all available bot commands.
-*   [`!command`](/chatbot/commands/default/command/): Manages custom commands.
-*   [`!module`](/chatbot/commands/default/module/): Enables or disables chatbot modules.
+*   [`!commands`](/chatbot/commands/default/commands): Lists all available bot commands.
+*   [`!command`](/chatbot/commands/default/command): Manages custom commands.
+*   [`!module`](/chatbot/commands/default/module): Enables or disables chatbot modules.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/commands/default/cancelduel.mdx
+++ b/src/content/docs/chatbot/commands/default/cancelduel.mdx
@@ -12,7 +12,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!cancelduel` command allows a user to cancel an **outgoing** duel request they initiated with the [`!duel`](/chatbot/commands/default/duel/) command *before* the challenged user accepts or denies it. If a request is never answered, it expires on its own after **2 minutes**.
+The `!cancelduel` command allows a user to cancel an **outgoing** duel request they initiated with the [`!duel`](/chatbot/commands/default/duel) command *before* the challenged user accepts or denies it. If a request is never answered, it expires on its own after **2 minutes**.
 
 ## Usage
 
@@ -62,6 +62,6 @@ The `!cancelduel` command is part of the **Duel module**. This module must be en
 
 ## Related Commands
 
-*   [`!duel`](/chatbot/commands/default/duel/): Initiate a duel with another user.
-*   [`!accept`](/chatbot/commands/default/accept/): Accept an incoming duel request.
-*   [`!deny`](/chatbot/commands/default/deny/): Deny an incoming duel request.
+*   [`!duel`](/chatbot/commands/default/duel): Initiate a duel with another user.
+*   [`!accept`](/chatbot/commands/default/accept): Accept an incoming duel request.
+*   [`!deny`](/chatbot/commands/default/deny): Deny an incoming duel request.

--- a/src/content/docs/chatbot/commands/default/cancelraffle.mdx
+++ b/src/content/docs/chatbot/commands/default/cancelraffle.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!cancelraffle` command allows streamers and moderators to immediately halt any active raffle or giveaway initiated by [`!raffle`](/chatbot/commands/default/raffle/) or [`!sraffle`](/chatbot/commands/default/sraffle/) on their channel.
+The `!cancelraffle` command allows streamers and moderators to immediately halt any active raffle or giveaway initiated by [`!raffle`](/chatbot/commands/default/raffle) or [`!sraffle`](/chatbot/commands/default/sraffle) on their channel.
 
 ## Usage
 
@@ -50,5 +50,5 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!raffle`](/chatbot/commands/default/raffle/): Starts a new raffle where users can enter multiple times (using points).
-*   [`!sraffle`](/chatbot/commands/default/sraffle/): Starts a new raffle where each user can only enter once (using keywords).
+*   [`!raffle`](/chatbot/commands/default/raffle): Starts a new raffle where users can enter multiple times (using points).
+*   [`!sraffle`](/chatbot/commands/default/sraffle): Starts a new raffle where each user can only enter once (using keywords).

--- a/src/content/docs/chatbot/commands/default/chatstats.mdx
+++ b/src/content/docs/chatbot/commands/default/chatstats.mdx
@@ -32,8 +32,8 @@ To get the link to the chat statistics page, simply type the command in chat:
 
 ## Related Commands
 
-*   [`!top`](/chatbot/commands/default/top/): Displays the top chatters or point leaders directly in chat.
-*   [`!emotecount`](/chatbot/commands/default/emotecount/): Checks how many times a specific emote has been used in chat.
-*   [`!uptime`](/chatbot/commands/default/uptime/): Shows how long the current stream has been live.
-*   [`!followage`](/chatbot/commands/default/followage/): Tells a user how long they've been following the channel (Twitch only).
-*   [`!watchtime`](/chatbot/commands/default/watchtime/): Shows how long a user has been watching the stream (requires Loyalty module).
+*   [`!top`](/chatbot/commands/default/top): Displays the top chatters or point leaders directly in chat.
+*   [`!emotecount`](/chatbot/commands/default/emotecount): Checks how many times a specific emote has been used in chat.
+*   [`!uptime`](/chatbot/commands/default/uptime): Shows how long the current stream has been live.
+*   [`!followage`](/chatbot/commands/default/followage): Tells a user how long they've been following the channel (Twitch only).
+*   [`!watchtime`](/chatbot/commands/default/watchtime): Shows how long a user has been watching the stream (requires Loyalty module).

--- a/src/content/docs/chatbot/commands/default/closestore.mdx
+++ b/src/content/docs/chatbot/commands/default/closestore.mdx
@@ -40,7 +40,7 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!openstore`](/chatbot/commands/default/openstore/): Re-enables all regular items in the loyalty store.
-*   [`!disablesfx`](/chatbot/commands/default/disablesfx/): Disables only sound effect (SFX) items in the loyalty store.
-*   [`!enablesfx`](/chatbot/commands/default/enablesfx/): Enables only sound effect (SFX) items in the loyalty store.
-*   [`!redeem`](/chatbot/commands/default/redeem/): Allows viewers to redeem store items.
+*   [`!openstore`](/chatbot/commands/default/openstore): Re-enables all regular items in the loyalty store.
+*   [`!disablesfx`](/chatbot/commands/default/disablesfx): Disables only sound effect (SFX) items in the loyalty store.
+*   [`!enablesfx`](/chatbot/commands/default/enablesfx): Enables only sound effect (SFX) items in the loyalty store.
+*   [`!redeem`](/chatbot/commands/default/redeem): Allows viewers to redeem store items.

--- a/src/content/docs/chatbot/commands/default/command.mdx
+++ b/src/content/docs/chatbot/commands/default/command.mdx
@@ -156,7 +156,7 @@ When using the `!command options` subcommand, you specify settings using flags f
 | `-trigger`       | **Renames the command**, changing the trigger word used to invoke it.                                                                   | `<new_name>` (e.g., `!links`)                                                | `-trigger !links`                         |
 | `-enable`        | Enables the command.                                                                                                                    | N/A                                                                        | `-enable`                                 |
 | `-disable`       | Disables the command, preventing anyone from using it.                                                                                 | N/A                                                                        | `-disable`                                |
-| `-count`         | **Manually sets the command's usage counter**, useful for resetting or adjusting the value used by [`$(count)`](/chatbot/variables/count/).     | `<number>` (e.g., `0`)                                                       | `-count 0`                                |
+| `-count`         | **Manually sets the command's usage counter**, useful for resetting or adjusting the value used by [`$(count)`](/chatbot/variables/count).     | `<number>` (e.g., `0`)                                                       | `-count 0`                                |
 
 ## Aliases
 
@@ -169,11 +169,11 @@ When using the `!command options` subcommand, you specify settings using flags f
 
 ## Related Commands
 
-*   [`!commands`](/chatbot/commands/default/commands/): Lists available commands.
-*   [`$(count)`](/chatbot/variables/count/): Variable to display the usage count of a command.
-*   [`$(user)`](/chatbot/variables/user/): Variable representing the user executing the command.
-*   [`$(channel)`](/chatbot/variables/channel/): Variable representing the channel name.
-*   See the full list of [Chatbot Variables](/chatbot/variables/).
+*   [`!commands`](/chatbot/commands/default/commands): Lists available commands.
+*   [`$(count)`](/chatbot/variables/count): Variable to display the usage count of a command.
+*   [`$(user)`](/chatbot/variables/user): Variable representing the user executing the command.
+*   [`$(channel)`](/chatbot/variables/channel): Variable representing the channel name.
+*   See the full list of [Chatbot Variables](/chatbot/variables).
 
 ## FAQ
 

--- a/src/content/docs/chatbot/commands/default/commands.mdx
+++ b/src/content/docs/chatbot/commands/default/commands.mdx
@@ -40,4 +40,4 @@ To get the link to the commands page, simply type the command in chat:
 
 ## Related Commands
 
-*   [`!command`](/chatbot/commands/default/command/): Used by moderators/streamers to manage custom commands directly via chat.
+*   [`!command`](/chatbot/commands/default/command): Used by moderators/streamers to manage custom commands directly via chat.

--- a/src/content/docs/chatbot/commands/default/contest.mdx
+++ b/src/content/docs/chatbot/commands/default/contest.mdx
@@ -47,4 +47,4 @@ To check the active contest details, simply type the command in chat:
 
 ## Related Commands
 
-*   [`!bet`](/chatbot/commands/default/bet/): Used by viewers to place bets on the active contest.
+*   [`!bet`](/chatbot/commands/default/bet): Used by viewers to place bets on the active contest.

--- a/src/content/docs/chatbot/commands/default/deny.mdx
+++ b/src/content/docs/chatbot/commands/default/deny.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!deny` command allows a user to reject an **incoming** duel request initiated by another user with the [`!duel`](/chatbot/commands/default/duel/) command. Duel requests expire on their own after **2 minutes** if neither accepted nor denied.
+The `!deny` command allows a user to reject an **incoming** duel request initiated by another user with the [`!duel`](/chatbot/commands/default/duel) command. Duel requests expire on their own after **2 minutes** if neither accepted nor denied.
 
 ## Usage
 
@@ -63,6 +63,6 @@ The `!deny` command is part of the **Duel module**. This module must be enabled 
 
 ## Related Commands
 
-*   [`!duel`](/chatbot/commands/default/duel/): Initiate a duel with another user.
-*   [`!accept`](/chatbot/commands/default/accept/): Accept an incoming duel request.
-*   [`!cancelduel`](/chatbot/commands/default/cancelduel/): Cancel an *outgoing* duel request you initiated.
+*   [`!duel`](/chatbot/commands/default/duel): Initiate a duel with another user.
+*   [`!accept`](/chatbot/commands/default/accept): Accept an incoming duel request.
+*   [`!cancelduel`](/chatbot/commands/default/cancelduel): Cancel an *outgoing* duel request you initiated.

--- a/src/content/docs/chatbot/commands/default/disablesfx.mdx
+++ b/src/content/docs/chatbot/commands/default/disablesfx.mdx
@@ -42,7 +42,7 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!enablesfx`](/chatbot/commands/default/enablesfx/): Re-enables all sound effect (SFX) items in the loyalty store.
-*   [`!closestore`](/chatbot/commands/default/closestore/): Disables all *regular* (non-SFX) items in the loyalty store.
-*   [`!openstore`](/chatbot/commands/default/openstore/): Enables all *regular* (non-SFX) items in the loyalty store.
-*   [`!redeem`](/chatbot/commands/default/redeem/): Allows viewers to redeem store items.
+*   [`!enablesfx`](/chatbot/commands/default/enablesfx): Re-enables all sound effect (SFX) items in the loyalty store.
+*   [`!closestore`](/chatbot/commands/default/closestore): Disables all *regular* (non-SFX) items in the loyalty store.
+*   [`!openstore`](/chatbot/commands/default/openstore): Enables all *regular* (non-SFX) items in the loyalty store.
+*   [`!redeem`](/chatbot/commands/default/redeem): Allows viewers to redeem store items.

--- a/src/content/docs/chatbot/commands/default/duel.mdx
+++ b/src/content/docs/chatbot/commands/default/duel.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!duel` command allows users to challenge another user in chat to a duel, optionally wagering their loyalty points. The challenged user then has **2 minutes** to respond using [`!accept`](/chatbot/commands/default/accept/) or [`!deny`](/chatbot/commands/default/deny/). If the duel is accepted, the winner is decided by a 50/50 coin flip — the winner gains the wagered points and the loser loses them.
+The `!duel` command allows users to challenge another user in chat to a duel, optionally wagering their loyalty points. The challenged user then has **2 minutes** to respond using [`!accept`](/chatbot/commands/default/accept) or [`!deny`](/chatbot/commands/default/deny). If the duel is accepted, the winner is decided by a 50/50 coin flip — the winner gains the wagered points and the loser loses them.
 
 ## Usage
 
@@ -72,7 +72,7 @@ Within the Duel module settings, you can customize:
 
 ## Related Commands
 
-*   [`!accept`](/chatbot/commands/default/accept/): Used by the challenged user to accept a duel.
-*   [`!deny`](/chatbot/commands/default/deny/): Used by the challenged user to decline a duel.
-*   [`!cancelduel`](/chatbot/commands/default/cancelduel/): Used by the challenger to cancel their *outgoing* duel request.
-*   [`!points`](/chatbot/commands/default/points/): Check your current loyalty points balance.
+*   [`!accept`](/chatbot/commands/default/accept): Used by the challenged user to accept a duel.
+*   [`!deny`](/chatbot/commands/default/deny): Used by the challenged user to decline a duel.
+*   [`!cancelduel`](/chatbot/commands/default/cancelduel): Used by the challenger to cancel their *outgoing* duel request.
+*   [`!points`](/chatbot/commands/default/points): Check your current loyalty points balance.

--- a/src/content/docs/chatbot/commands/default/emotecount.mdx
+++ b/src/content/docs/chatbot/commands/default/emotecount.mdx
@@ -55,7 +55,7 @@ To check the count for a specific emote, use the following syntax:
 
 ## Related Commands
 
-*   [`!emotes`](/chatbot/commands/default/emotes/): Provides a link to view the channel's available third-party emotes (BTTV, FFZ, 7TV).
+*   [`!emotes`](/chatbot/commands/default/emotes): Provides a link to view the channel's available third-party emotes (BTTV, FFZ, 7TV).
 
 ## FAQ
 

--- a/src/content/docs/chatbot/commands/default/emotes.mdx
+++ b/src/content/docs/chatbot/commands/default/emotes.mdx
@@ -68,4 +68,4 @@ Using `!emotes reload` requires **Moderator** permission level or higher by defa
 
 ## Related Commands
 
-*   [`!emotecount`](/chatbot/commands/default/emotecount/): Checks how many times a specific emote has been used in chat.
+*   [`!emotecount`](/chatbot/commands/default/emotecount): Checks how many times a specific emote has been used in chat.

--- a/src/content/docs/chatbot/commands/default/enablesfx.mdx
+++ b/src/content/docs/chatbot/commands/default/enablesfx.mdx
@@ -47,7 +47,7 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!disablesfx`](/chatbot/commands/default/disablesfx/): Disables all sound effect (SFX) items in the loyalty store.
-*   [`!closestore`](/chatbot/commands/default/closestore/): Disables all *regular* (non-SFX) items in the loyalty store.
-*   [`!openstore`](/chatbot/commands/default/openstore/): Enables all *regular* (non-SFX) items in the loyalty store.
-*   [`!redeem`](/chatbot/commands/default/redeem/): Allows viewers to redeem store items.
+*   [`!disablesfx`](/chatbot/commands/default/disablesfx): Disables all sound effect (SFX) items in the loyalty store.
+*   [`!closestore`](/chatbot/commands/default/closestore): Disables all *regular* (non-SFX) items in the loyalty store.
+*   [`!openstore`](/chatbot/commands/default/openstore): Enables all *regular* (non-SFX) items in the loyalty store.
+*   [`!redeem`](/chatbot/commands/default/redeem): Allows viewers to redeem store items.

--- a/src/content/docs/chatbot/commands/default/filesay.mdx
+++ b/src/content/docs/chatbot/commands/default/filesay.mdx
@@ -61,5 +61,5 @@ To execute the commands/messages from a file URL:
 
 ## Related Commands
 
-*   [`!nuke`](/chatbot/commands/default/nuke/): Times out all users who recently chatted based on a specific phrase.
-*   [`!nukeusername`](/chatbot/commands/default/nukeusername/): Times out all users whose usernames match a pattern.
+*   [`!nuke`](/chatbot/commands/default/nuke): Times out all users who recently chatted based on a specific phrase.
+*   [`!nukeusername`](/chatbot/commands/default/nukeusername): Times out all users whose usernames match a pattern.

--- a/src/content/docs/chatbot/commands/default/followage.mdx
+++ b/src/content/docs/chatbot/commands/default/followage.mdx
@@ -50,6 +50,6 @@ Use the command with optional parameters:
 
 ## Related Commands
 
-*   [`!accountage`](/chatbot/commands/default/accountage/): Checks when a Twitch account was created.
-*   [`!uptime`](/chatbot/commands/default/uptime/): Shows how long the current stream has been live.
-*   [`!watchtime`](/chatbot/commands/default/watchtime/): Shows how long a user has watched the current channel (requires Loyalty module).
+*   [`!accountage`](/chatbot/commands/default/accountage): Checks when a Twitch account was created.
+*   [`!uptime`](/chatbot/commands/default/uptime): Shows how long the current stream has been live.
+*   [`!watchtime`](/chatbot/commands/default/watchtime): Shows how long a user has watched the current channel (requires Loyalty module).

--- a/src/content/docs/chatbot/commands/default/giveaway.mdx
+++ b/src/content/docs/chatbot/commands/default/giveaway.mdx
@@ -47,5 +47,5 @@ To check the active giveaway details, simply type the command in chat:
 
 ## Related Commands
 
-*   [`!ticket`](/chatbot/commands/default/ticket/): Used by viewers to enter the active giveaway (if it requires loyalty points).
-*   [`!raffle`](/chatbot/commands/default/raffle/) / [`!sraffle`](/chatbot/commands/default/sraffle/): Commands for different types of raffle/giveaway systems.
+*   [`!ticket`](/chatbot/commands/default/ticket): Used by viewers to enter the active giveaway (if it requires loyalty points).
+*   [`!raffle`](/chatbot/commands/default/raffle) / [`!sraffle`](/chatbot/commands/default/sraffle): Commands for different types of raffle/giveaway systems.

--- a/src/content/docs/chatbot/commands/default/givepoints.mdx
+++ b/src/content/docs/chatbot/commands/default/givepoints.mdx
@@ -63,7 +63,7 @@ To transfer points to another user:
 
 ## Related Commands
 
-*   [`!points`](/chatbot/commands/default/points/): Check your own or another user's point balance.
-*   [`!addpoints`](/chatbot/commands/default/addpoints/): (Moderator+) Manually add points to a user.
-*   [`!setpoints`](/chatbot/commands/default/setpoints/): (Moderator+) Set a user's points to a specific value.
-*   [`!top`](/chatbot/commands/default/top/): View the leaderboard for points.
+*   [`!points`](/chatbot/commands/default/points): Check your own or another user's point balance.
+*   [`!addpoints`](/chatbot/commands/default/addpoints): (Moderator+) Manually add points to a user.
+*   [`!setpoints`](/chatbot/commands/default/setpoints): (Moderator+) Set a user's points to a specific value.
+*   [`!top`](/chatbot/commands/default/top): View the leaderboard for points.

--- a/src/content/docs/chatbot/commands/default/index.md
+++ b/src/content/docs/chatbot/commands/default/index.md
@@ -24,122 +24,122 @@ Below is the full list of default commands, grouped by what they do. Click on ea
 
 | Command | Description |
 | --- | --- |
-| [`!addpoints`](/chatbot/commands/default/addpoints/) | Moderators add loyalty points to a viewer. |
-| [`!givepoints`](/chatbot/commands/default/givepoints/) | Transfer your loyalty points to another user. |
-| [`!leaderboard`](/chatbot/commands/default/leaderboard/) | Get a link to the points or watch time leaderboard page. |
-| [`!points`](/chatbot/commands/default/points/) | Check your own or another user's points balance and rank. |
-| [`!setpoints`](/chatbot/commands/default/setpoints/) | Moderators set a user's loyalty points balance. |
-| [`!top`](/chatbot/commands/default/top/) | Display the top users by loyalty points or watch time. |
-| [`!watchtime`](/chatbot/commands/default/watchtime/) | Check your own or another user's accumulated watch time. |
+| [`!addpoints`](/chatbot/commands/default/addpoints) | Moderators add loyalty points to a viewer. |
+| [`!givepoints`](/chatbot/commands/default/givepoints) | Transfer your loyalty points to another user. |
+| [`!leaderboard`](/chatbot/commands/default/leaderboard) | Get a link to the points or watch time leaderboard page. |
+| [`!points`](/chatbot/commands/default/points) | Check your own or another user's points balance and rank. |
+| [`!setpoints`](/chatbot/commands/default/setpoints) | Moderators set a user's loyalty points balance. |
+| [`!top`](/chatbot/commands/default/top) | Display the top users by loyalty points or watch time. |
+| [`!watchtime`](/chatbot/commands/default/watchtime) | Check your own or another user's accumulated watch time. |
 
 ## Games & Betting
 
 | Command | Description |
 | --- | --- |
-| [`!accept`](/chatbot/commands/default/accept/) | Accept a pending duel challenge. |
-| [`!bet`](/chatbot/commands/default/bet/) | Place loyalty points on an active betting contest. |
-| [`!bingo`](/chatbot/commands/default/bingo/) | Emote bingo game; viewers guess emotes to win loyalty points. |
-| [`!cancelduel`](/chatbot/commands/default/cancelduel/) | Cancel an outgoing duel request you initiated. |
-| [`!contest`](/chatbot/commands/default/contest/) | Check the status of the currently active betting contest. |
-| [`!deny`](/chatbot/commands/default/deny/) | Reject an incoming duel request. |
-| [`!duel`](/chatbot/commands/default/duel/) | Challenge another user to a points duel. |
-| [`!roulette`](/chatbot/commands/default/roulette/) | Gamble loyalty points for a chance to win or lose. |
-| [`!slots`](/chatbot/commands/default/slots/) | Play a slot machine game with loyalty points. |
+| [`!accept`](/chatbot/commands/default/accept) | Accept a pending duel challenge. |
+| [`!bet`](/chatbot/commands/default/bet) | Place loyalty points on an active betting contest. |
+| [`!bingo`](/chatbot/commands/default/bingo) | Emote bingo game; viewers guess emotes to win loyalty points. |
+| [`!cancelduel`](/chatbot/commands/default/cancelduel) | Cancel an outgoing duel request you initiated. |
+| [`!contest`](/chatbot/commands/default/contest) | Check the status of the currently active betting contest. |
+| [`!deny`](/chatbot/commands/default/deny) | Reject an incoming duel request. |
+| [`!duel`](/chatbot/commands/default/duel) | Challenge another user to a points duel. |
+| [`!roulette`](/chatbot/commands/default/roulette) | Gamble loyalty points for a chance to win or lose. |
+| [`!slots`](/chatbot/commands/default/slots) | Play a slot machine game with loyalty points. |
 
 ## Giveaways & Raffles
 
 | Command | Description |
 | --- | --- |
-| [`!cancelraffle`](/chatbot/commands/default/cancelraffle/) | Immediately cancel an active raffle. |
-| [`!giveaway`](/chatbot/commands/default/giveaway/) | Check the status and link of the active channel giveaway. |
-| [`!join`](/chatbot/commands/default/join/) | Enter an active raffle or giveaway started with `!sraffle` or `!raffle`. |
-| [`!raffle`](/chatbot/commands/default/raffle/) | Create viewer raffles with multiple winners. |
-| [`!sraffle`](/chatbot/commands/default/sraffle/) | Start a single-entry raffle; viewers enter with `!join`. |
-| [`!ticket`](/chatbot/commands/default/ticket/) | Purchase tickets for giveaways and raffles. |
+| [`!cancelraffle`](/chatbot/commands/default/cancelraffle) | Immediately cancel an active raffle. |
+| [`!giveaway`](/chatbot/commands/default/giveaway) | Check the status and link of the active channel giveaway. |
+| [`!join`](/chatbot/commands/default/join) | Enter an active raffle or giveaway started with `!sraffle` or `!raffle`. |
+| [`!raffle`](/chatbot/commands/default/raffle) | Create viewer raffles with multiple winners. |
+| [`!sraffle`](/chatbot/commands/default/sraffle) | Start a single-entry raffle; viewers enter with `!join`. |
+| [`!ticket`](/chatbot/commands/default/ticket) | Purchase tickets for giveaways and raffles. |
 
 ## Song Requests
 
 | Command | Description |
 | --- | --- |
-| [`!next`](/chatbot/commands/default/next/) | Show the next song in the media request queue. |
-| [`!pause`](/chatbot/commands/default/pause/) | Pause media request playback without clearing the queue. |
-| [`!play`](/chatbot/commands/default/play/) | Resume paused media request playback. |
-| [`!removesong`](/chatbot/commands/default/removesong/) | Remove a song by URL, or all of a user's songs. |
-| [`!skip`](/chatbot/commands/default/skip/) | Moderators skip the current song in the queue. |
-| [`!song`](/chatbot/commands/default/song/) | Show the currently playing song. |
-| [`!songqueue`](/chatbot/commands/default/songqueue/) | Get a link to the current media request queue page. |
-| [`!songrequest`](/chatbot/commands/default/songrequest/) | Add YouTube songs or videos to the media request queue. |
-| [`!srclear`](/chatbot/commands/default/srclear/) | Clear the entire media request queue. |
-| [`!volume`](/chatbot/commands/default/volume/) | Check or set the media request player volume. |
-| [`!voteskip`](/chatbot/commands/default/voteskip/) | Let viewers vote to skip the current media request. |
-| [`!when`](/chatbot/commands/default/when/) | Check the queue position of your latest song request. |
-| [`!wrongsong`](/chatbot/commands/default/wrongsong/) | Remove the last song you added to the queue. |
+| [`!next`](/chatbot/commands/default/next) | Show the next song in the media request queue. |
+| [`!pause`](/chatbot/commands/default/pause) | Pause media request playback without clearing the queue. |
+| [`!play`](/chatbot/commands/default/play) | Resume paused media request playback. |
+| [`!removesong`](/chatbot/commands/default/removesong) | Remove a song by URL, or all of a user's songs. |
+| [`!skip`](/chatbot/commands/default/skip) | Moderators skip the current song in the queue. |
+| [`!song`](/chatbot/commands/default/song) | Show the currently playing song. |
+| [`!songqueue`](/chatbot/commands/default/songqueue) | Get a link to the current media request queue page. |
+| [`!songrequest`](/chatbot/commands/default/songrequest) | Add YouTube songs or videos to the media request queue. |
+| [`!srclear`](/chatbot/commands/default/srclear) | Clear the entire media request queue. |
+| [`!volume`](/chatbot/commands/default/volume) | Check or set the media request player volume. |
+| [`!voteskip`](/chatbot/commands/default/voteskip) | Let viewers vote to skip the current media request. |
+| [`!when`](/chatbot/commands/default/when) | Check the queue position of your latest song request. |
+| [`!wrongsong`](/chatbot/commands/default/wrongsong) | Remove the last song you added to the queue. |
 
 ## Viewer Queue
 
 | Command | Description |
 | --- | --- |
-| [`!queue`](/chatbot/commands/default/queue/) | Manage viewer queues for activities like playing with the streamer. |
+| [`!queue`](/chatbot/commands/default/queue) | Manage viewer queues for activities like playing with the streamer. |
 
 ## Store
 
 | Command | Description |
 | --- | --- |
-| [`!closestore`](/chatbot/commands/default/closestore/) | Disable all regular (non-SFX) items in the loyalty store. |
-| [`!disablesfx`](/chatbot/commands/default/disablesfx/) | Disable all sound effect (SFX) items in the loyalty store. |
-| [`!enablesfx`](/chatbot/commands/default/enablesfx/) | Re-enable all sound effect (SFX) items in the loyalty store. |
-| [`!items`](/chatbot/commands/default/items/) | Get a link to the channel's loyalty store page. |
-| [`!openstore`](/chatbot/commands/default/openstore/) | Re-enable all regular (non-SFX) items in the loyalty store. |
-| [`!redeem`](/chatbot/commands/default/redeem/) | Redeem loyalty store items using points. |
+| [`!closestore`](/chatbot/commands/default/closestore) | Disable all regular (non-SFX) items in the loyalty store. |
+| [`!disablesfx`](/chatbot/commands/default/disablesfx) | Disable all sound effect (SFX) items in the loyalty store. |
+| [`!enablesfx`](/chatbot/commands/default/enablesfx) | Re-enable all sound effect (SFX) items in the loyalty store. |
+| [`!items`](/chatbot/commands/default/items) | Get a link to the channel's loyalty store page. |
+| [`!openstore`](/chatbot/commands/default/openstore) | Re-enable all regular (non-SFX) items in the loyalty store. |
+| [`!redeem`](/chatbot/commands/default/redeem) | Redeem loyalty store items using points. |
 
 ## Stream Management
 
 | Command | Description |
 | --- | --- |
-| [`!alerts`](/chatbot/commands/default/alerts/) | Mute, skip, or pause overlay alerts from chat. |
-| [`!editcounter`](/chatbot/commands/default/editcounter/) | Set, increment, or decrement custom counter values from chat. |
-| [`!hypecup`](/chatbot/commands/default/hypecup/) | Clear the HypeCup overlay contribution list. |
-| [`!setgame`](/chatbot/commands/default/setgame/) | Update the stream's game category on Twitch. |
-| [`!settitle`](/chatbot/commands/default/settitle/) | Moderators change the Twitch stream title. |
-| [`!timer`](/chatbot/commands/default/timer/) | Enable or disable specific chat timers. |
+| [`!alerts`](/chatbot/commands/default/alerts) | Mute, skip, or pause overlay alerts from chat. |
+| [`!editcounter`](/chatbot/commands/default/editcounter) | Set, increment, or decrement custom counter values from chat. |
+| [`!hypecup`](/chatbot/commands/default/hypecup) | Clear the HypeCup overlay contribution list. |
+| [`!setgame`](/chatbot/commands/default/setgame) | Update the stream's game category on Twitch. |
+| [`!settitle`](/chatbot/commands/default/settitle) | Moderators change the Twitch stream title. |
+| [`!timer`](/chatbot/commands/default/timer) | Enable or disable specific chat timers. |
 
 ## Moderation
 
 | Command | Description |
 | --- | --- |
-| [`!filesay`](/chatbot/commands/default/filesay/) | Send multiple lines of text from a URL to chat. |
-| [`!level`](/chatbot/commands/default/level/) | View and manually override user permission levels. |
-| [`!nuke`](/chatbot/commands/default/nuke/) | Timeout, ban, or delete recent messages matching text or regex. |
-| [`!nukeusername`](/chatbot/commands/default/nukeusername/) | Timeout or ban users whose usernames match text or regex. |
-| [`!permit`](/chatbot/commands/default/permit/) | Temporarily allow a user to post links without being timed out. |
-| [`!vanish`](/chatbot/commands/default/vanish/) | Time yourself out for 1 second to clear your messages. |
-| [`!votekick`](/chatbot/commands/default/votekick/) | Start a community vote to temporarily kick a user. |
+| [`!filesay`](/chatbot/commands/default/filesay) | Send multiple lines of text from a URL to chat. |
+| [`!level`](/chatbot/commands/default/level) | View and manually override user permission levels. |
+| [`!nuke`](/chatbot/commands/default/nuke) | Timeout, ban, or delete recent messages matching text or regex. |
+| [`!nukeusername`](/chatbot/commands/default/nukeusername) | Timeout or ban users whose usernames match text or regex. |
+| [`!permit`](/chatbot/commands/default/permit) | Temporarily allow a user to post links without being timed out. |
+| [`!vanish`](/chatbot/commands/default/vanish) | Time yourself out for 1 second to clear your messages. |
+| [`!votekick`](/chatbot/commands/default/votekick) | Start a community vote to temporarily kick a user. |
 
 ## Bot & Command Management
 
 | Command | Description |
 | --- | --- |
-| [`!bot`](/chatbot/commands/default/bot/) | Mute, unmute, or remove the bot from chat. |
-| [`!command`](/chatbot/commands/default/command/) | Add, remove, edit, or alias custom commands from chat. |
-| [`!commands`](/chatbot/commands/default/commands/) | Get a link to the channel's public commands list. |
-| [`!module`](/chatbot/commands/default/module/) | Enable or disable chatbot modules from chat. |
+| [`!bot`](/chatbot/commands/default/bot) | Mute, unmute, or remove the bot from chat. |
+| [`!command`](/chatbot/commands/default/command) | Add, remove, edit, or alias custom commands from chat. |
+| [`!commands`](/chatbot/commands/default/commands) | Get a link to the channel's public commands list. |
+| [`!module`](/chatbot/commands/default/module) | Enable or disable chatbot modules from chat. |
 
 ## Fun & Emotes
 
 | Command | Description |
 | --- | --- |
-| [`!8ball`](/chatbot/commands/default/8ball/) | Receive a random magic 8-ball style answer to a question. |
-| [`!emotecount`](/chatbot/commands/default/emotecount/) | Display the usage frequency of a specific emote. |
-| [`!emotes`](/chatbot/commands/default/emotes/) | List Twitch, BTTV, FFZ, or 7TV emotes, or reload the cache. |
-| [`!kappagen`](/chatbot/commands/default/kappagen/) | Trigger an emote explosion via the Kappagen overlay widget. |
-| [`!quote`](/chatbot/commands/default/quote/) | Display random saved quotes or manage the quote list. |
+| [`!8ball`](/chatbot/commands/default/8ball) | Receive a random magic 8-ball style answer to a question. |
+| [`!emotecount`](/chatbot/commands/default/emotecount) | Display the usage frequency of a specific emote. |
+| [`!emotes`](/chatbot/commands/default/emotes) | List Twitch, BTTV, FFZ, or 7TV emotes, or reload the cache. |
+| [`!kappagen`](/chatbot/commands/default/kappagen) | Trigger an emote explosion via the Kappagen overlay widget. |
+| [`!quote`](/chatbot/commands/default/quote) | Display random saved quotes or manage the quote list. |
 
 ## Stream Info & Utility
 
 | Command | Description |
 | --- | --- |
-| [`!accountage`](/chatbot/commands/default/accountage/) | Check the creation date of any Twitch account. |
-| [`!chatstats`](/chatbot/commands/default/chatstats/) | Get a link to the channel's chat statistics page. |
-| [`!followage`](/chatbot/commands/default/followage/) | Check how long a user has been following the channel. |
-| [`!tip`](/chatbot/commands/default/tip/) | Get a link to the channel's tipping page. |
-| [`!uptime`](/chatbot/commands/default/uptime/) | Check the current stream's duration. |
+| [`!accountage`](/chatbot/commands/default/accountage) | Check the creation date of any Twitch account. |
+| [`!chatstats`](/chatbot/commands/default/chatstats) | Get a link to the channel's chat statistics page. |
+| [`!followage`](/chatbot/commands/default/followage) | Check how long a user has been following the channel. |
+| [`!tip`](/chatbot/commands/default/tip) | Get a link to the channel's tipping page. |
+| [`!uptime`](/chatbot/commands/default/uptime) | Check the current stream's duration. |

--- a/src/content/docs/chatbot/commands/default/items.mdx
+++ b/src/content/docs/chatbot/commands/default/items.mdx
@@ -36,7 +36,7 @@ To get the link to the store page, simply type the command in chat:
 
 ## Related Commands
 
-*   [`!points`](/chatbot/commands/default/points/): Check your current loyalty point balance.
-*   [`!redeem`](/chatbot/commands/default/redeem/): Allows viewers to redeem a specific store item directly via chat.
-*   [`!closestore`](/chatbot/commands/default/closestore/) / [`!openstore`](/chatbot/commands/default/openstore/): (Moderator+) Commands to enable/disable regular store items.
-*   [`!disablesfx`](/chatbot/commands/default/disablesfx/) / [`!enablesfx`](/chatbot/commands/default/enablesfx/): (Moderator+) Commands to enable/disable sound effect store items.
+*   [`!points`](/chatbot/commands/default/points): Check your current loyalty point balance.
+*   [`!redeem`](/chatbot/commands/default/redeem): Allows viewers to redeem a specific store item directly via chat.
+*   [`!closestore`](/chatbot/commands/default/closestore) / [`!openstore`](/chatbot/commands/default/openstore): (Moderator+) Commands to enable/disable regular store items.
+*   [`!disablesfx`](/chatbot/commands/default/disablesfx) / [`!enablesfx`](/chatbot/commands/default/enablesfx): (Moderator+) Commands to enable/disable sound effect store items.

--- a/src/content/docs/chatbot/commands/default/join.mdx
+++ b/src/content/docs/chatbot/commands/default/join.mdx
@@ -13,12 +13,12 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!join` command allows viewers to enter an **active raffle** in the chat. Viewers use this command to participate in raffles started by moderators using either [`!sraffle`](/chatbot/commands/default/sraffle/) or [`!raffle`](/chatbot/commands/default/raffle/). Entry is **free** — joining a raffle never costs points (points are the prize, not the entry fee) — and each viewer can only enter once per raffle; repeat `!join` messages are ignored.
+The `!join` command allows viewers to enter an **active raffle** in the chat. Viewers use this command to participate in raffles started by moderators using either [`!sraffle`](/chatbot/commands/default/sraffle) or [`!raffle`](/chatbot/commands/default/raffle). Entry is **free** — joining a raffle never costs points (points are the prize, not the entry fee) — and each viewer can only enter once per raffle; repeat `!join` messages are ignored.
 
 The command only does something while a raffle is running. If no raffle is active, `!join` does nothing.
 
 :::note
-`!join` does **not** add you to the viewer queue. To enter the viewer queue, use [`!queue join`](/chatbot/commands/default/queue/) instead.
+`!join` does **not** add you to the viewer queue. To enter the viewer queue, use [`!queue join`](/chatbot/commands/default/queue) instead.
 :::
 
 ## Usage
@@ -46,7 +46,7 @@ There are **no parameters** for this command.
 
 ## Related Commands
 
-*   [`!sraffle`](/chatbot/commands/default/sraffle/): Starts a single-winner raffle where one entrant wins the full points prize.
-*   [`!raffle`](/chatbot/commands/default/raffle/): Starts a multi-winner raffle where the points prize is split between the winners.
-*   [`!cancelraffle`](/chatbot/commands/default/cancelraffle/): Cancels the active raffle.
-*   [`!queue join`](/chatbot/commands/default/queue/): Enters the viewer queue (not related to raffles).
+*   [`!sraffle`](/chatbot/commands/default/sraffle): Starts a single-winner raffle where one entrant wins the full points prize.
+*   [`!raffle`](/chatbot/commands/default/raffle): Starts a multi-winner raffle where the points prize is split between the winners.
+*   [`!cancelraffle`](/chatbot/commands/default/cancelraffle): Cancels the active raffle.
+*   [`!queue join`](/chatbot/commands/default/queue): Enters the viewer queue (not related to raffles).

--- a/src/content/docs/chatbot/commands/default/kappagen.mdx
+++ b/src/content/docs/chatbot/commands/default/kappagen.mdx
@@ -38,5 +38,5 @@ To trigger the emote explosion:
 
 ## Related Commands
 
-*   [`!emotes`](/chatbot/commands/default/emotes/): Provides a link to the channel's available emotes.
-*   [`!alerts`](/chatbot/commands/default/alerts/): Manages other overlay alert functions.
+*   [`!emotes`](/chatbot/commands/default/emotes): Provides a link to the channel's available emotes.
+*   [`!alerts`](/chatbot/commands/default/alerts): Manages other overlay alert functions.

--- a/src/content/docs/chatbot/commands/default/leaderboard.mdx
+++ b/src/content/docs/chatbot/commands/default/leaderboard.mdx
@@ -38,6 +38,6 @@ To get the link to the leaderboard page, simply type the command in chat:
 
 ## Related Commands
 
-*   [`!points`](/chatbot/commands/default/points/): Check your current loyalty point balance.
-*   [`!watchtime`](/chatbot/commands/default/watchtime/): Check your accumulated watch time.
-*   [`!top`](/chatbot/commands/default/top/): Shows the top users (points or time) directly in chat.
+*   [`!points`](/chatbot/commands/default/points): Check your current loyalty point balance.
+*   [`!watchtime`](/chatbot/commands/default/watchtime): Check your accumulated watch time.
+*   [`!top`](/chatbot/commands/default/top): Shows the top users (points or time) directly in chat.

--- a/src/content/docs/chatbot/commands/default/level.mdx
+++ b/src/content/docs/chatbot/commands/default/level.mdx
@@ -91,7 +91,7 @@ Manually setting a level (e.g., setting a non-sub to `250`) grants them the perm
 
 ## Related Commands
 
-*   [`!permit`](/chatbot/commands/default/permit/): Temporarily grants link permission to a user, often used for users below a certain level.
+*   [`!permit`](/chatbot/commands/default/permit): Temporarily grants link permission to a user, often used for users below a certain level.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/commands/default/module.mdx
+++ b/src/content/docs/chatbot/commands/default/module.mdx
@@ -52,5 +52,5 @@ To enable or disable a module:
 
 ## Related Commands
 
-*   [`!bot`](/chatbot/commands/default/bot/): Controls the bot's overall presence (mute/unmute/part).
-*   [`!commands`](/chatbot/commands/default/commands/): Provides a link to the list of commands (which are often tied to modules).
+*   [`!bot`](/chatbot/commands/default/bot): Controls the bot's overall presence (mute/unmute/part).
+*   [`!commands`](/chatbot/commands/default/commands): Provides a link to the list of commands (which are often tied to modules).

--- a/src/content/docs/chatbot/commands/default/next.mdx
+++ b/src/content/docs/chatbot/commands/default/next.mdx
@@ -13,7 +13,7 @@ platforms: [twitch]
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!next` command (aliased as `!nextsong`) allows anyone in chat to view details about the upcoming song in the StreamElements media request queue. It shows the channel, song title, requester, and a link. It only **displays** the next queued song — it does not skip anything; skipping is done by moderators with [`!skip`](/chatbot/commands/default/skip/).
+The `!next` command (aliased as `!nextsong`) allows anyone in chat to view details about the upcoming song in the StreamElements media request queue. It shows the channel, song title, requester, and a link. It only **displays** the next queued song — it does not skip anything; skipping is done by moderators with [`!skip`](/chatbot/commands/default/skip).
 
 ## Usage
 
@@ -55,8 +55,8 @@ Or using the alias:
 
 ## Related Commands
 
-*   [`!song`](/chatbot/commands/default/song/): Shows details about the *currently playing* song.
-*   [`!songqueue`](/chatbot/commands/default/songqueue/): Provides a link to the full media request queue.
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Allows users to request songs to add to the queue.
-*   [`!skip`](/chatbot/commands/default/skip/): (Moderator+) Skips the currently playing song.
-*   [`!removesong`](/chatbot/commands/default/removesong/): (Moderator+) Removes a specific song from the queue.
+*   [`!song`](/chatbot/commands/default/song): Shows details about the *currently playing* song.
+*   [`!songqueue`](/chatbot/commands/default/songqueue): Provides a link to the full media request queue.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Allows users to request songs to add to the queue.
+*   [`!skip`](/chatbot/commands/default/skip): (Moderator+) Skips the currently playing song.
+*   [`!removesong`](/chatbot/commands/default/removesong): (Moderator+) Removes a specific song from the queue.

--- a/src/content/docs/chatbot/commands/default/nuke.mdx
+++ b/src/content/docs/chatbot/commands/default/nuke.mdx
@@ -67,5 +67,5 @@ By default, only users with **Super Moderator** permission level or higher can u
 
 ## Related Commands
 
-*   [`!nukeusername`](/chatbot/commands/default/nukeusername/): Performs similar actions but matches against usernames instead of message content.
-*   [`!filesay`](/chatbot/commands/default/filesay/): Executes commands line-by-line from a text file URL, useful for banning specific lists of users.
+*   [`!nukeusername`](/chatbot/commands/default/nukeusername): Performs similar actions but matches against usernames instead of message content.
+*   [`!filesay`](/chatbot/commands/default/filesay): Executes commands line-by-line from a text file URL, useful for banning specific lists of users.

--- a/src/content/docs/chatbot/commands/default/nukeusername.mdx
+++ b/src/content/docs/chatbot/commands/default/nukeusername.mdx
@@ -61,5 +61,5 @@ By default, only users with **Super Moderator** permission level or higher can u
 
 ## Related Commands
 
-*   [`!nuke`](/chatbot/commands/default/nuke/): Performs similar actions but matches against message content instead of usernames.
-*   [`!filesay`](/chatbot/commands/default/filesay/): Executes commands line-by-line from a text file URL, useful for banning specific lists of users.
+*   [`!nuke`](/chatbot/commands/default/nuke): Performs similar actions but matches against message content instead of usernames.
+*   [`!filesay`](/chatbot/commands/default/filesay): Executes commands line-by-line from a text file URL, useful for banning specific lists of users.

--- a/src/content/docs/chatbot/commands/default/openstore.mdx
+++ b/src/content/docs/chatbot/commands/default/openstore.mdx
@@ -45,8 +45,8 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!closestore`](/chatbot/commands/default/closestore/): Disables all *regular* (non-SFX) items in the loyalty store.
-*   [`!disablesfx`](/chatbot/commands/default/disablesfx/): Disables only sound effect (SFX) items in the loyalty store.
-*   [`!enablesfx`](/chatbot/commands/default/enablesfx/): Enables only sound effect (SFX) items in the loyalty store.
-*   [`!redeem`](/chatbot/commands/default/redeem/): Allows viewers to redeem store items.
-*   [`!items`](/chatbot/commands/default/items/): Provides a link to the store page.
+*   [`!closestore`](/chatbot/commands/default/closestore): Disables all *regular* (non-SFX) items in the loyalty store.
+*   [`!disablesfx`](/chatbot/commands/default/disablesfx): Disables only sound effect (SFX) items in the loyalty store.
+*   [`!enablesfx`](/chatbot/commands/default/enablesfx): Enables only sound effect (SFX) items in the loyalty store.
+*   [`!redeem`](/chatbot/commands/default/redeem): Allows viewers to redeem store items.
+*   [`!items`](/chatbot/commands/default/items): Provides a link to the store page.

--- a/src/content/docs/chatbot/commands/default/pause.mdx
+++ b/src/content/docs/chatbot/commands/default/pause.mdx
@@ -39,8 +39,8 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!play`](/chatbot/commands/default/play/): Resumes media playback after it has been paused.
-*   [`!skip`](/chatbot/commands/default/skip/): Skips the currently playing media item.
-*   [`!volume`](/chatbot/commands/default/volume/): Adjusts the volume of the media player.
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Adds a song/video to the queue.
-*   [`!songqueue`](/chatbot/commands/default/songqueue/): Provides a link to the media queue page.
+*   [`!play`](/chatbot/commands/default/play): Resumes media playback after it has been paused.
+*   [`!skip`](/chatbot/commands/default/skip): Skips the currently playing media item.
+*   [`!volume`](/chatbot/commands/default/volume): Adjusts the volume of the media player.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Adds a song/video to the queue.
+*   [`!songqueue`](/chatbot/commands/default/songqueue): Provides a link to the media queue page.

--- a/src/content/docs/chatbot/commands/default/permit.mdx
+++ b/src/content/docs/chatbot/commands/default/permit.mdx
@@ -54,4 +54,4 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!level`](/chatbot/commands/default/level/): Used to view or set a user's permanent permission level, which can also control link permissions.
+*   [`!level`](/chatbot/commands/default/level): Used to view or set a user's permanent permission level, which can also control link permissions.

--- a/src/content/docs/chatbot/commands/default/play.mdx
+++ b/src/content/docs/chatbot/commands/default/play.mdx
@@ -12,7 +12,7 @@ platforms: [twitch]
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!play` command (aliased as `!resume`) resumes the playback of the StreamElements media request queue after it has been stopped by the [`!pause`](/chatbot/commands/default/pause/) command.
+The `!play` command (aliased as `!resume`) resumes the playback of the StreamElements media request queue after it has been stopped by the [`!pause`](/chatbot/commands/default/pause) command.
 
 ## Usage
 
@@ -50,8 +50,8 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!pause`](/chatbot/commands/default/pause/): Pauses the current media playback.
-*   [`!skip`](/chatbot/commands/default/skip/): Skips the currently playing media item.
-*   [`!volume`](/chatbot/commands/default/volume/): Adjusts the volume of the media player.
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Adds a song/video to the queue.
-*   [`!songqueue`](/chatbot/commands/default/songqueue/): Provides a link to the media queue page.
+*   [`!pause`](/chatbot/commands/default/pause): Pauses the current media playback.
+*   [`!skip`](/chatbot/commands/default/skip): Skips the currently playing media item.
+*   [`!volume`](/chatbot/commands/default/volume): Adjusts the volume of the media player.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Adds a song/video to the queue.
+*   [`!songqueue`](/chatbot/commands/default/songqueue): Provides a link to the media queue page.

--- a/src/content/docs/chatbot/commands/default/points.mdx
+++ b/src/content/docs/chatbot/commands/default/points.mdx
@@ -52,7 +52,7 @@ The command also triggers on your channel's custom points name. For example, if 
 
 ## Related Commands
 
-*   [`!top`](/chatbot/commands/default/top/): Shows the top users on the leaderboard directly in chat.
-*   [`!leaderboard`](/chatbot/commands/default/leaderboard/): Provides a link to the full leaderboard page.
-*   [`!givepoints`](/chatbot/commands/default/givepoints/): Allows users to transfer points to each other.
-*   [`!addpoints`](/chatbot/commands/default/addpoints/) / [`!setpoints`](/chatbot/commands/default/setpoints/): (Moderator+) Commands to modify user points.
+*   [`!top`](/chatbot/commands/default/top): Shows the top users on the leaderboard directly in chat.
+*   [`!leaderboard`](/chatbot/commands/default/leaderboard): Provides a link to the full leaderboard page.
+*   [`!givepoints`](/chatbot/commands/default/givepoints): Allows users to transfer points to each other.
+*   [`!addpoints`](/chatbot/commands/default/addpoints) / [`!setpoints`](/chatbot/commands/default/setpoints): (Moderator+) Commands to modify user points.

--- a/src/content/docs/chatbot/commands/default/queue.mdx
+++ b/src/content/docs/chatbot/commands/default/queue.mdx
@@ -39,7 +39,7 @@ Here's a breakdown of the available subcommands:
 Allows a viewer to enter the open queue.
 
 :::note
-You must type the full `!queue join` to enter the viewer queue. The standalone [`!join`](/chatbot/commands/default/join/) command is unrelated — it enters an active raffle instead.
+You must type the full `!queue join` to enter the viewer queue. The standalone [`!join`](/chatbot/commands/default/join) command is unrelated — it enters an active raffle instead.
 :::
 
 *   **Syntax:** `!queue join`
@@ -152,4 +152,4 @@ Removes a specific user from the queue.
 
 ## Related
 
-*   [Viewer Queue Module](/chatbot/modules/viewerqueue/): Enable the queue and configure its settings (size limits, messages, and behavior) in the StreamElements Dashboard.
+*   [Viewer Queue Module](/chatbot/modules/viewerqueue): Enable the queue and configure its settings (size limits, messages, and behavior) in the StreamElements Dashboard.

--- a/src/content/docs/chatbot/commands/default/quote.mdx
+++ b/src/content/docs/chatbot/commands/default/quote.mdx
@@ -96,4 +96,4 @@ Quotes cannot be **edited** from chat — only added and removed. To edit the te
 
 ## Related Variables
 
-*   [`$(quote <id>)`](/chatbot/variables/quote/): Variable to display a specific quote by ID.
+*   [`$(quote <id>)`](/chatbot/variables/quote): Variable to display a specific quote by ID.

--- a/src/content/docs/chatbot/commands/default/raffle.mdx
+++ b/src/content/docs/chatbot/commands/default/raffle.mdx
@@ -53,5 +53,5 @@ Moderators can configure raffle settings, such as the maximum number of winners 
 
 ## Related Commands
 
-- [`!join`](/chatbot/commands/default/join/): Used by viewers to enter an active raffle.
-- [`!cancelraffle`](/chatbot/commands/default/cancelraffle/): Allows moderators to cancel an ongoing raffle.
+- [`!join`](/chatbot/commands/default/join): Used by viewers to enter an active raffle.
+- [`!cancelraffle`](/chatbot/commands/default/cancelraffle): Allows moderators to cancel an ongoing raffle.

--- a/src/content/docs/chatbot/commands/default/redeem.mdx
+++ b/src/content/docs/chatbot/commands/default/redeem.mdx
@@ -56,7 +56,7 @@ To redeem an item:
 
 ## Related Commands
 
-*   [`!items`](/chatbot/commands/default/items/): Provides a link to the store page listing available items.
-*   [`!points`](/chatbot/commands/default/points/): Checks the user's current point balance.
-*   [`!closestore`](/chatbot/commands/default/closestore/) / [`!openstore`](/chatbot/commands/default/openstore/): (Moderator+) Enable/disable regular store items.
-*   [`!disablesfx`](/chatbot/commands/default/disablesfx/) / [`!enablesfx`](/chatbot/commands/default/enablesfx/): (Moderator+) Enable/disable SFX store items.
+*   [`!items`](/chatbot/commands/default/items): Provides a link to the store page listing available items.
+*   [`!points`](/chatbot/commands/default/points): Checks the user's current point balance.
+*   [`!closestore`](/chatbot/commands/default/closestore) / [`!openstore`](/chatbot/commands/default/openstore): (Moderator+) Enable/disable regular store items.
+*   [`!disablesfx`](/chatbot/commands/default/disablesfx) / [`!enablesfx`](/chatbot/commands/default/enablesfx): (Moderator+) Enable/disable SFX store items.

--- a/src/content/docs/chatbot/commands/default/removesong.mdx
+++ b/src/content/docs/chatbot/commands/default/removesong.mdx
@@ -61,7 +61,7 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Adds a song/video to the queue.
-*   [`!songqueue`](/chatbot/commands/default/songqueue/): Provides a link to the media queue page.
-*   [`!skip`](/chatbot/commands/default/skip/): Skips the *currently playing* song.
-*   [`!play`](/chatbot/commands/default/play/) / [`!pause`](/chatbot/commands/default/pause/): Controls playback.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Adds a song/video to the queue.
+*   [`!songqueue`](/chatbot/commands/default/songqueue): Provides a link to the media queue page.
+*   [`!skip`](/chatbot/commands/default/skip): Skips the *currently playing* song.
+*   [`!play`](/chatbot/commands/default/play) / [`!pause`](/chatbot/commands/default/pause): Controls playback.

--- a/src/content/docs/chatbot/commands/default/roulette.mdx
+++ b/src/content/docs/chatbot/commands/default/roulette.mdx
@@ -80,5 +80,5 @@ To play roulette:
 
 ## Related Commands
 
-*   [`!points`](/chatbot/commands/default/points/): Check current point balance.
-*   [`!duel`](/chatbot/commands/default/duel/) / [`!slots`](/chatbot/commands/default/slots/) / [`!bet`](/chatbot/commands/default/bet/): Other points-based games (if enabled).
+*   [`!points`](/chatbot/commands/default/points): Check current point balance.
+*   [`!duel`](/chatbot/commands/default/duel) / [`!slots`](/chatbot/commands/default/slots) / [`!bet`](/chatbot/commands/default/bet): Other points-based games (if enabled).

--- a/src/content/docs/chatbot/commands/default/setgame.mdx
+++ b/src/content/docs/chatbot/commands/default/setgame.mdx
@@ -49,5 +49,5 @@ To set the game category for the stream:
 
 ## Related Commands
 
-*   [`!settitle`](/chatbot/commands/default/settitle/): Updates the stream title.
-*   [`!uptime`](/chatbot/commands/default/uptime/): Displays how long the stream has been live.
+*   [`!settitle`](/chatbot/commands/default/settitle): Updates the stream title.
+*   [`!uptime`](/chatbot/commands/default/uptime): Displays how long the stream has been live.

--- a/src/content/docs/chatbot/commands/default/setpoints.mdx
+++ b/src/content/docs/chatbot/commands/default/setpoints.mdx
@@ -16,7 +16,7 @@ import ChatExample from '@components/ChatExample.astro';
 The `!setpoints` command allows streamers and moderators to set a specific number of loyalty points for a user in the chat. This command is useful for managing loyalty programs, rewarding viewers, or correcting point balances.
 
 :::caution
-Using this command will **overwrite** the user's current point balance. Use [`!addpoints`](/chatbot/commands/default/addpoints/) if you want to add to their balance instead.
+Using this command will **overwrite** the user's current point balance. Use [`!addpoints`](/chatbot/commands/default/addpoints) if you want to add to their balance instead.
 :::
 
 :::caution[Permissions]
@@ -55,7 +55,7 @@ To set a user's point balance:
 
 ## Related Commands
 
-*   [`!addpoints`](/chatbot/commands/default/addpoints/): Adds points to a user's balance without overwriting.
-*   [`!givepoints`](/chatbot/commands/default/givepoints/): Allows users to transfer points.
-*   [`!points`](/chatbot/commands/default/points/): Checks a user's current point balance.
-*   [`!top`](/chatbot/commands/default/top/): View the leaderboard for points.
+*   [`!addpoints`](/chatbot/commands/default/addpoints): Adds points to a user's balance without overwriting.
+*   [`!givepoints`](/chatbot/commands/default/givepoints): Allows users to transfer points.
+*   [`!points`](/chatbot/commands/default/points): Checks a user's current point balance.
+*   [`!top`](/chatbot/commands/default/top): View the leaderboard for points.

--- a/src/content/docs/chatbot/commands/default/settitle.mdx
+++ b/src/content/docs/chatbot/commands/default/settitle.mdx
@@ -51,5 +51,5 @@ To set the stream title:
 
 ## Related Commands
 
-*   [`!setgame`](/chatbot/commands/default/setgame/): Changes the current game/category of the stream.
-*   [`!uptime`](/chatbot/commands/default/uptime/): Displays how long the stream has been live.
+*   [`!setgame`](/chatbot/commands/default/setgame): Changes the current game/category of the stream.
+*   [`!uptime`](/chatbot/commands/default/uptime): Displays how long the stream has been live.

--- a/src/content/docs/chatbot/commands/default/skip.mdx
+++ b/src/content/docs/chatbot/commands/default/skip.mdx
@@ -19,7 +19,7 @@ By default, only users with **Moderator** permission level or higher can use thi
 :::
 
 :::note[!skip vs !next]
-`!skip` is a moderator action that **skips the currently playing song**. It is different from [`!next`](/chatbot/commands/default/next/), which simply **shows** the next queued song and is available to everyone.
+`!skip` is a moderator action that **skips the currently playing song**. It is different from [`!next`](/chatbot/commands/default/next), which simply **shows** the next queued song and is available to everyone.
 :::
 
 ## Usage
@@ -53,9 +53,9 @@ To use the `!skip` command, simply type it in the chat:
 
 ## Related Commands
 
-*   [`!song`](/chatbot/commands/default/song/): Displays information about the currently playing song.
-*   [`!next`](/chatbot/commands/default/next/): Displays information about the next song in the queue.
-*   [`!songqueue`](/chatbot/commands/default/songqueue/): Shows the current media request queue.
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Adds a song to the media request queue.
-*   [`!removesong`](/chatbot/commands/default/removesong/): Removes a song from the queue.
-*   [`!play`](/chatbot/commands/default/play/) / [`!pause`](/chatbot/commands/default/pause/): Controls playback.
+*   [`!song`](/chatbot/commands/default/song): Displays information about the currently playing song.
+*   [`!next`](/chatbot/commands/default/next): Displays information about the next song in the queue.
+*   [`!songqueue`](/chatbot/commands/default/songqueue): Shows the current media request queue.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Adds a song to the media request queue.
+*   [`!removesong`](/chatbot/commands/default/removesong): Removes a song from the queue.
+*   [`!play`](/chatbot/commands/default/play) / [`!pause`](/chatbot/commands/default/pause): Controls playback.

--- a/src/content/docs/chatbot/commands/default/slots.mdx
+++ b/src/content/docs/chatbot/commands/default/slots.mdx
@@ -68,5 +68,5 @@ The **Loyalty system** must also be active for the `!slots` command to function,
 
 ## Related Commands
 
-*   [`!points`](/chatbot/commands/default/points/): Check your current loyalty points balance.
-*   [`!roulette`](/chatbot/commands/default/roulette/) / [`!duel`](/chatbot/commands/default/duel/) / [`!bet`](/chatbot/commands/default/bet/): Other points-based games (if enabled).
+*   [`!points`](/chatbot/commands/default/points): Check your current loyalty points balance.
+*   [`!roulette`](/chatbot/commands/default/roulette) / [`!duel`](/chatbot/commands/default/duel) / [`!bet`](/chatbot/commands/default/bet): Other points-based games (if enabled).

--- a/src/content/docs/chatbot/commands/default/song.mdx
+++ b/src/content/docs/chatbot/commands/default/song.mdx
@@ -44,8 +44,8 @@ To use the `!song` command, simply type it in the chat:
 
 ## Related Commands
 
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Used to add songs to the media request queue.
-*   [`!skip`](/chatbot/commands/default/skip/): (Moderator+) Used to skip the current song.
-*   [`!next`](/chatbot/commands/default/next/): Shows details about the *next* song in the queue.
-*   [`!songqueue`](/chatbot/commands/default/songqueue/): Shows the upcoming songs in the media request queue.
-*   [`!play`](/chatbot/commands/default/play/) / [`!pause`](/chatbot/commands/default/pause/): (Moderator+) Controls playback.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Used to add songs to the media request queue.
+*   [`!skip`](/chatbot/commands/default/skip): (Moderator+) Used to skip the current song.
+*   [`!next`](/chatbot/commands/default/next): Shows details about the *next* song in the queue.
+*   [`!songqueue`](/chatbot/commands/default/songqueue): Shows the upcoming songs in the media request queue.
+*   [`!play`](/chatbot/commands/default/play) / [`!pause`](/chatbot/commands/default/pause): (Moderator+) Controls playback.

--- a/src/content/docs/chatbot/commands/default/songqueue.mdx
+++ b/src/content/docs/chatbot/commands/default/songqueue.mdx
@@ -48,7 +48,7 @@ Type `!songqueue` in the chat to receive a link to the media request queue page:
 
 ## Related Commands
 
-*   [`!songrequest`](/chatbot/commands/default/songrequest/) / `!sr`: Used to request a song or media to be added to the queue.
-*   [`!wrongsong`](/chatbot/commands/default/wrongsong/): Allows users to remove their most recent song request from the queue.
-*   [`!song`](/chatbot/commands/default/song/): Displays information about the currently playing song or media.
-*   [`!next`](/chatbot/commands/default/next/): Displays information about the next song in the queue.
+*   [`!songrequest`](/chatbot/commands/default/songrequest) / `!sr`: Used to request a song or media to be added to the queue.
+*   [`!wrongsong`](/chatbot/commands/default/wrongsong): Allows users to remove their most recent song request from the queue.
+*   [`!song`](/chatbot/commands/default/song): Displays information about the currently playing song or media.
+*   [`!next`](/chatbot/commands/default/next): Displays information about the next song in the queue.

--- a/src/content/docs/chatbot/commands/default/songrequest.mdx
+++ b/src/content/docs/chatbot/commands/default/songrequest.mdx
@@ -74,10 +74,10 @@ Or using the alias:
 
 ## Related Commands
 
-*   [`!songqueue`](/chatbot/commands/default/songqueue/): View the current media request queue.
-*   [`!song`](/chatbot/commands/default/song/): Displays information about the currently playing song.
-*   [`!next`](/chatbot/commands/default/next/): Displays information about the next song in the queue.
-*   [`!wrongsong`](/chatbot/commands/default/wrongsong/): Allows users to remove their most recent song request.
-*   [`!skip`](/chatbot/commands/default/skip/): (Moderator+) Skips the currently playing song.
-*   [`!volume`](/chatbot/commands/default/volume/): Checks or adjusts the volume of the media player.
-*   [`!removesong`](/chatbot/commands/default/removesong/): (Moderator+) Removes a specific song or all songs by a user.
+*   [`!songqueue`](/chatbot/commands/default/songqueue): View the current media request queue.
+*   [`!song`](/chatbot/commands/default/song): Displays information about the currently playing song.
+*   [`!next`](/chatbot/commands/default/next): Displays information about the next song in the queue.
+*   [`!wrongsong`](/chatbot/commands/default/wrongsong): Allows users to remove their most recent song request.
+*   [`!skip`](/chatbot/commands/default/skip): (Moderator+) Skips the currently playing song.
+*   [`!volume`](/chatbot/commands/default/volume): Checks or adjusts the volume of the media player.
+*   [`!removesong`](/chatbot/commands/default/removesong): (Moderator+) Removes a specific song or all songs by a user.

--- a/src/content/docs/chatbot/commands/default/sraffle.mdx
+++ b/src/content/docs/chatbot/commands/default/sraffle.mdx
@@ -12,7 +12,7 @@ platforms: [twitch]
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!sraffle` command allows streamers and moderators to start a **single-winner raffle**. The command randomly selects **one winner** from all the viewers who entered using the [`!join`](/chatbot/commands/default/join/) command (entry is free, one entry per viewer), and that winner receives the **full points prize**. For a raffle with multiple winners that split the prize, use [`!raffle`](/chatbot/commands/default/raffle/) instead.
+The `!sraffle` command allows streamers and moderators to start a **single-winner raffle**. The command randomly selects **one winner** from all the viewers who entered using the [`!join`](/chatbot/commands/default/join) command (entry is free, one entry per viewer), and that winner receives the **full points prize**. For a raffle with multiple winners that split the prize, use [`!raffle`](/chatbot/commands/default/raffle) instead.
 
 
 ## Usage
@@ -58,7 +58,7 @@ By default, only users with **Moderator** permission level or higher can use thi
 
 ## Related Commands
 
-*   [`!join`](/chatbot/commands/default/join/): The command viewers use to enter an active `!sraffle`.
-*   [`!raffle`](/chatbot/commands/default/raffle/): (Moderator+) Starts a multi-winner raffle where the points prize is split between the winners.
-*   [`!cancelraffle`](/chatbot/commands/default/cancelraffle/): (Moderator+) Cancels the currently active raffle (`!raffle` or `!sraffle`).
-*   [`!giveaway`](/chatbot/commands/default/giveaway/): Checks the status of the main channel giveaway.
+*   [`!join`](/chatbot/commands/default/join): The command viewers use to enter an active `!sraffle`.
+*   [`!raffle`](/chatbot/commands/default/raffle): (Moderator+) Starts a multi-winner raffle where the points prize is split between the winners.
+*   [`!cancelraffle`](/chatbot/commands/default/cancelraffle): (Moderator+) Cancels the currently active raffle (`!raffle` or `!sraffle`).
+*   [`!giveaway`](/chatbot/commands/default/giveaway): Checks the status of the main channel giveaway.

--- a/src/content/docs/chatbot/commands/default/srclear.mdx
+++ b/src/content/docs/chatbot/commands/default/srclear.mdx
@@ -47,7 +47,7 @@ To clear the queue, simply type the command in chat:
 
 ## Related Commands
 
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Used to request a song.
-*   [`!removesong`](/chatbot/commands/default/removesong/): Removes a specific song or all songs by a user.
-*   [`!wrongsong`](/chatbot/commands/default/wrongsong/): Allows users to remove their most recent song request.
-*   [`!skip`](/chatbot/commands/default/skip/): Skips the currently playing song in the queue.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Used to request a song.
+*   [`!removesong`](/chatbot/commands/default/removesong): Removes a specific song or all songs by a user.
+*   [`!wrongsong`](/chatbot/commands/default/wrongsong): Allows users to remove their most recent song request.
+*   [`!skip`](/chatbot/commands/default/skip): Skips the currently playing song in the queue.

--- a/src/content/docs/chatbot/commands/default/ticket.mdx
+++ b/src/content/docs/chatbot/commands/default/ticket.mdx
@@ -64,8 +64,8 @@ Streamers configure giveaway settings, including ticket cost and the maximum num
 
 ## Related Commands
 
--   [`!giveaway`](/chatbot/commands/default/giveaway/): Used by moderators to start or manage giveaways.
--   [`!points`](/chatbot/commands/default/points/): Allows users to check their current loyalty points balance.
+-   [`!giveaway`](/chatbot/commands/default/giveaway): Used by moderators to start or manage giveaways.
+-   [`!points`](/chatbot/commands/default/points): Allows users to check their current loyalty points balance.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/commands/default/timer.mdx
+++ b/src/content/docs/chatbot/commands/default/timer.mdx
@@ -51,4 +51,4 @@ To enable or disable a timer:
 
 ## Related Commands
 
-*   [`!command`](/chatbot/commands/default/command/): Manages custom commands, which can sometimes serve similar purposes to simple timers.
+*   [`!command`](/chatbot/commands/default/command): Manages custom commands, which can sometimes serve similar purposes to simple timers.

--- a/src/content/docs/chatbot/commands/default/top.mdx
+++ b/src/content/docs/chatbot/commands/default/top.mdx
@@ -60,6 +60,6 @@ If `[type]` is omitted, the points leaderboard is shown. The command displays th
 
 ## Related Commands
 
-*   [`!points`](/chatbot/commands/default/points/): Checks an individual user's points and rank.
-*   [`!watchtime`](/chatbot/commands/default/watchtime/): Checks an individual user's watch time.
-*   [`!leaderboard`](/chatbot/commands/default/leaderboard/): Provides a link to the full web-based leaderboard.
+*   [`!points`](/chatbot/commands/default/points): Checks an individual user's points and rank.
+*   [`!watchtime`](/chatbot/commands/default/watchtime): Checks an individual user's watch time.
+*   [`!leaderboard`](/chatbot/commands/default/leaderboard): Provides a link to the full web-based leaderboard.

--- a/src/content/docs/chatbot/commands/default/uptime.mdx
+++ b/src/content/docs/chatbot/commands/default/uptime.mdx
@@ -36,6 +36,6 @@ To check the stream duration, simply type the command in the chat:
 
 ## Related Commands
 
-*   [`!followage`](/chatbot/commands/default/followage/): Checks how long a user has followed (Twitch).
-*   [`!watchtime`](/chatbot/commands/default/watchtime/): Checks a user's accumulated watch time.
-*   [`!accountage`](/chatbot/commands/default/accountage/): Checks when a user account was created.
+*   [`!followage`](/chatbot/commands/default/followage): Checks how long a user has followed (Twitch).
+*   [`!watchtime`](/chatbot/commands/default/watchtime): Checks a user's accumulated watch time.
+*   [`!accountage`](/chatbot/commands/default/accountage): Checks when a user account was created.

--- a/src/content/docs/chatbot/commands/default/vanish.mdx
+++ b/src/content/docs/chatbot/commands/default/vanish.mdx
@@ -37,5 +37,5 @@ To use the `!vanish` command, simply type it in the chat:
 
 ## Related Commands
 
-*   [`!nuke`](/chatbot/commands/default/nuke/): (Moderator+) Bulk timeout, ban, or delete recent messages matching specific text or regex.
-*   [`!permit`](/chatbot/commands/default/permit/): (Moderator+) Temporarily allows a user to post links without being timed out.
+*   [`!nuke`](/chatbot/commands/default/nuke): (Moderator+) Bulk timeout, ban, or delete recent messages matching specific text or regex.
+*   [`!permit`](/chatbot/commands/default/permit): (Moderator+) Temporarily allows a user to post links without being timed out.

--- a/src/content/docs/chatbot/commands/default/volume.mdx
+++ b/src/content/docs/chatbot/commands/default/volume.mdx
@@ -69,6 +69,6 @@ By default, **everyone** can use this command — both to check and to set the v
 
 ## Related Commands
 
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Used to request songs or media content.
-*   [`!skip`](/chatbot/commands/default/skip/): Skips the currently playing media request.
-*   [`!play`](/chatbot/commands/default/play/) / [`!pause`](/chatbot/commands/default/pause/): Controls media playback.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Used to request songs or media content.
+*   [`!skip`](/chatbot/commands/default/skip): Skips the currently playing media request.
+*   [`!play`](/chatbot/commands/default/play) / [`!pause`](/chatbot/commands/default/pause): Controls media playback.

--- a/src/content/docs/chatbot/commands/default/votekick.mdx
+++ b/src/content/docs/chatbot/commands/default/votekick.mdx
@@ -66,5 +66,5 @@ To start a vote to kick a user:
 
 ## Related
 
-*   [`!nuke`](/chatbot/commands/default/nuke/): (Moderator+) Bulk timeout, ban, or delete recent messages matching specific text or regex.
-*   [Votekick Module](/chatbot/modules/votekick/): Configure the votekick settings (vote duration, thresholds, timeout duration, and cooldowns).
+*   [`!nuke`](/chatbot/commands/default/nuke): (Moderator+) Bulk timeout, ban, or delete recent messages matching specific text or regex.
+*   [Votekick Module](/chatbot/modules/votekick): Configure the votekick settings (vote duration, thresholds, timeout duration, and cooldowns).

--- a/src/content/docs/chatbot/commands/default/voteskip.mdx
+++ b/src/content/docs/chatbot/commands/default/voteskip.mdx
@@ -45,8 +45,8 @@ To cast a vote to skip the current media:
 
 ## Related Commands
 
-*   [`!song`](/chatbot/commands/default/song/): Displays information about the currently playing song or media.
-*   [`!next`](/chatbot/commands/default/next/): Displays information about the next song in the queue.
-*   [`!wrongsong`](/chatbot/commands/default/wrongsong/): Allows users to remove their own song request from the queue.
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Lets viewers request songs or media to be played.
-*   [`!skip`](/chatbot/commands/default/skip/): (Moderator+) Immediately skips the current media.
+*   [`!song`](/chatbot/commands/default/song): Displays information about the currently playing song or media.
+*   [`!next`](/chatbot/commands/default/next): Displays information about the next song in the queue.
+*   [`!wrongsong`](/chatbot/commands/default/wrongsong): Allows users to remove their own song request from the queue.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Lets viewers request songs or media to be played.
+*   [`!skip`](/chatbot/commands/default/skip): (Moderator+) Immediately skips the current media.

--- a/src/content/docs/chatbot/commands/default/watchtime.mdx
+++ b/src/content/docs/chatbot/commands/default/watchtime.mdx
@@ -47,7 +47,7 @@ To check watch time:
 
 ## Related Commands
 
-*   [`!points`](/chatbot/commands/default/points/): Checks the loyalty points balance.
-*   [`!top`](/chatbot/commands/default/top/): Shows the top viewers by watch time or points.
-*   [`!leaderboard`](/chatbot/commands/default/leaderboard/): Provides a link to the full leaderboard.
-*   [`!uptime`](/chatbot/commands/default/uptime/): Shows the duration of the *current* stream session.
+*   [`!points`](/chatbot/commands/default/points): Checks the loyalty points balance.
+*   [`!top`](/chatbot/commands/default/top): Shows the top viewers by watch time or points.
+*   [`!leaderboard`](/chatbot/commands/default/leaderboard): Provides a link to the full leaderboard.
+*   [`!uptime`](/chatbot/commands/default/uptime): Shows the duration of the *current* stream session.

--- a/src/content/docs/chatbot/commands/default/when.mdx
+++ b/src/content/docs/chatbot/commands/default/when.mdx
@@ -57,8 +57,8 @@ To check the queue position of a specific song:
 
 ## Related Commands
 
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Used to request a song.
-*   [`!wrongsong`](/chatbot/commands/default/wrongsong/): Removes your last song request.
-*   [`!songqueue`](/chatbot/commands/default/songqueue/): Provides a link to the full queue.
-*   [`!song`](/chatbot/commands/default/song/): Shows the currently playing song.
-*   [`!next`](/chatbot/commands/default/next/): Shows the next song in the queue.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Used to request a song.
+*   [`!wrongsong`](/chatbot/commands/default/wrongsong): Removes your last song request.
+*   [`!songqueue`](/chatbot/commands/default/songqueue): Provides a link to the full queue.
+*   [`!song`](/chatbot/commands/default/song): Shows the currently playing song.
+*   [`!next`](/chatbot/commands/default/next): Shows the next song in the queue.

--- a/src/content/docs/chatbot/commands/default/wrongsong.mdx
+++ b/src/content/docs/chatbot/commands/default/wrongsong.mdx
@@ -48,8 +48,8 @@ To remove your last song request, simply type the command in chat:
 
 ## Related Commands
 
-*   [`!songrequest`](/chatbot/commands/default/songrequest/): Used to add a song to the request queue.
-*   [`!when`](/chatbot/commands/default/when/): Checks the status of your last requested song.
-*   [`!songqueue`](/chatbot/commands/default/songqueue/): Provides a link to the full queue.
-*   [`!song`](/chatbot/commands/default/song/): Displays information about the currently playing song.
-*   [`!next`](/chatbot/commands/default/next/): Shows the next song in the queue.
+*   [`!songrequest`](/chatbot/commands/default/songrequest): Used to add a song to the request queue.
+*   [`!when`](/chatbot/commands/default/when): Checks the status of your last requested song.
+*   [`!songqueue`](/chatbot/commands/default/songqueue): Provides a link to the full queue.
+*   [`!song`](/chatbot/commands/default/song): Displays information about the currently playing song.
+*   [`!next`](/chatbot/commands/default/next): Shows the next song in the queue.

--- a/src/content/docs/chatbot/commands/index.mdx
+++ b/src/content/docs/chatbot/commands/index.mdx
@@ -11,22 +11,22 @@ keywords:
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-The StreamElements Chatbot supports two kinds of chat commands. Default commands are pre-configured and ready to use immediately, covering moderation, viewer engagement, and stream information. Custom commands are commands you create yourself, with responses that can include [variables](/chatbot/variables/) for dynamic content.
+The StreamElements Chatbot supports two kinds of chat commands. Default commands are pre-configured and ready to use immediately, covering moderation, viewer engagement, and stream information. Custom commands are commands you create yourself, with responses that can include [variables](/chatbot/variables) for dynamic content.
 
 <CardGrid>
   <LinkCard
     title="Custom Commands"
-    href="/chatbot/commands/custom/"
+    href="/chatbot/commands/custom"
     description="Create commands tailored to your channel and community."
   />
   <LinkCard
     title="Default Commands"
-    href="/chatbot/commands/default/"
+    href="/chatbot/commands/default"
     description="Pre-configured commands that are ready to use immediately."
   />
   <LinkCard
     title="Variables"
-    href="/chatbot/variables/"
+    href="/chatbot/variables"
     description="Dynamic values for command and timer responses."
   />
 </CardGrid>

--- a/src/content/docs/chatbot/counters.md
+++ b/src/content/docs/chatbot/counters.md
@@ -17,8 +17,8 @@ You can manage your counters in the [StreamElements Dashboard](https://streamele
 
 ## Variables
 
-- `getcount` - Retrieves the current count of the counter. For more information, refer to the [getcount documentation](/chatbot/variables/getcount/).
-- `count` - Increments or decrements the counter. For more information, refer to the [count documentation](/chatbot/variables/count/).
+- `getcount` - Retrieves the current count of the counter. For more information, refer to the [getcount documentation](/chatbot/variables/getcount).
+- `count` - Increments or decrements the counter. For more information, refer to the [count documentation](/chatbot/variables/count).
 
 ## Examples
 
@@ -42,6 +42,6 @@ Let's create another command to see how many cannons you've missed (without incr
 
 ## Related
 
-- [!editcounter](/chatbot/commands/default/editcounter/) - Set, increment, or decrement a counter's value from chat
-- [$(count)](/chatbot/variables/count/) - Increments or decrements a counter
-- [$(getcount)](/chatbot/variables/getcount/) - Retrieves the current count without changing it
+- [!editcounter](/chatbot/commands/default/editcounter) - Set, increment, or decrement a counter's value from chat
+- [$(count)](/chatbot/variables/count) - Increments or decrements a counter
+- [$(getcount)](/chatbot/variables/getcount) - Retrieves the current count without changing it

--- a/src/content/docs/chatbot/filters/bannedwords.md
+++ b/src/content/docs/chatbot/filters/bannedwords.md
@@ -23,7 +23,7 @@ Banned phrases are organized into groups. Click the **Add Group** button to crea
 
 | Setting | Description |
 |---------|-------------|
-| Timeout length | Controls the action taken when a phrase in this group matches — a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). This per-group value takes precedence over the filter-wide timeout. See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation). |
+| Timeout length | Controls the action taken when a phrase in this group matches — a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). This per-group value takes precedence over the filter-wide timeout. See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation). |
 | Scan section | Which parts of a chat message the group checks: the message text, the sender's username, or both. |
 | Exclude user group | A user-level threshold. Users at or above the selected level (for example, Moderators and above) are not checked against this group. |
 | Ban reason | The moderation reason attached to the timeout or ban. |

--- a/src/content/docs/chatbot/filters/caps.md
+++ b/src/content/docs/chatbot/filters/caps.md
@@ -21,8 +21,8 @@ The Caps filter helps manage the use of capital letters in chat messages. It che
 | Minimum characters | The minimum number of characters a message must have before the filter checks for a violation. If a message contains fewer characters than this limit, it will not be checked by the filter. |
 | Maximum percent | The maximum percentage of a message that can be capital letters. If the percentage of capital letters in a message exceeds this limit, it will be flagged by the filter. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters/#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
 
 ## What happens on a violation
 
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation) for details.
+The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.

--- a/src/content/docs/chatbot/filters/emotes.md
+++ b/src/content/docs/chatbot/filters/emotes.md
@@ -19,8 +19,8 @@ The Emote filter helps manage the use of emotes in chat messages. It checks the 
 |---------|-------------|
 | Maximum amount | The maximum number of emotes allowed in a message. If a message contains more emotes than this limit, it will be flagged by the filter. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters/#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
 
 ## What happens on a violation
 
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation) for details.
+The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.

--- a/src/content/docs/chatbot/filters/index.mdx
+++ b/src/content/docs/chatbot/filters/index.mdx
@@ -50,7 +50,7 @@ In addition to its own thresholds, every filter supports these common settings:
 
 The moderation reason sent to the platform is your timeout message with " - automated by StreamElements" appended; the chat announcement uses the message as-is.
 
-Filters never apply to the channel owner or to platform staff. Moderators can also use the [!permit](/chatbot/commands/default/permit/) command to give a user a 30-second pass that bypasses all filters.
+Filters never apply to the channel owner or to platform staff. Moderators can also use the [!permit](/chatbot/commands/default/permit) command to give a user a 30-second pass that bypasses all filters.
 
 ## What happens on a violation
 
@@ -70,14 +70,14 @@ When one message violates several filters at once, only the harshest action is t
 ## Available Filters
 
 <CardGrid>
-  <LinkCard title="Banned Words" href="/chatbot/filters/bannedwords/" description="Remove messages containing banned phrases and regular expression patterns." />
-  <LinkCard title="Caps" href="/chatbot/filters/caps/" description="Limit excessive use of capital letters in chat messages." />
-  <LinkCard title="Emotes" href="/chatbot/filters/emotes/" description="Limit the number of emotes allowed in a single message." />
-  <LinkCard title="Language" href="/chatbot/filters/language/" description="Remove messages written in languages you haven't allowed." />
-  <LinkCard title="Links" href="/chatbot/filters/links/" description="Control link posting in chat with allowlists and blocklists." />
-  <LinkCard title="One-Man Spam" href="/chatbot/filters/one-man-spam/" description="Stop a single user from flooding chat with repeated messages." />
-  <LinkCard title="Paragraph" href="/chatbot/filters/paragraph/" description="Limit the maximum length of chat messages." />
-  <LinkCard title="Repetition" href="/chatbot/filters/repetition/" description="Limit excessive repetition of characters and sequences." />
-  <LinkCard title="Symbol" href="/chatbot/filters/symbol/" description="Limit the number and percentage of symbols in chat messages." />
-  <LinkCard title="Zalgo" href="/chatbot/filters/zalgo/" description="Remove zalgo and other combining-character text." />
+  <LinkCard title="Banned Words" href="/chatbot/filters/bannedwords" description="Remove messages containing banned phrases and regular expression patterns." />
+  <LinkCard title="Caps" href="/chatbot/filters/caps" description="Limit excessive use of capital letters in chat messages." />
+  <LinkCard title="Emotes" href="/chatbot/filters/emotes" description="Limit the number of emotes allowed in a single message." />
+  <LinkCard title="Language" href="/chatbot/filters/language" description="Remove messages written in languages you haven't allowed." />
+  <LinkCard title="Links" href="/chatbot/filters/links" description="Control link posting in chat with allowlists and blocklists." />
+  <LinkCard title="One-Man Spam" href="/chatbot/filters/one-man-spam" description="Stop a single user from flooding chat with repeated messages." />
+  <LinkCard title="Paragraph" href="/chatbot/filters/paragraph" description="Limit the maximum length of chat messages." />
+  <LinkCard title="Repetition" href="/chatbot/filters/repetition" description="Limit excessive repetition of characters and sequences." />
+  <LinkCard title="Symbol" href="/chatbot/filters/symbol" description="Limit the number and percentage of symbols in chat messages." />
+  <LinkCard title="Zalgo" href="/chatbot/filters/zalgo" description="Remove zalgo and other combining-character text." />
 </CardGrid>

--- a/src/content/docs/chatbot/filters/language.md
+++ b/src/content/docs/chatbot/filters/language.md
@@ -15,8 +15,8 @@ The Language filter moderates messages based on the language they are written in
 
 ## Settings
 
-The filter supports the [settings shared by all filters](/chatbot/filters/#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
+The filter supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
 
 ## What happens on a violation
 
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation) for details.
+The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.

--- a/src/content/docs/chatbot/filters/links.md
+++ b/src/content/docs/chatbot/filters/links.md
@@ -23,10 +23,10 @@ The Link filter helps manage the posting of links in chat messages. It checks if
 
 Both lists support the `*` wildcard character for flexible rules, and patterns are matched case-insensitively.
 
-The filter also supports the [settings shared by all filters](/chatbot/filters/#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
 
 ## What happens on a violation
 
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation) for details.
+The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
 
 Links matching the blocklist receive a harsher punishment: when the action is a timeout, the user is timed out for **double** the configured duration. With any other action (delete only, ban, or warning), the configured action applies as-is.

--- a/src/content/docs/chatbot/filters/one-man-spam.md
+++ b/src/content/docs/chatbot/filters/one-man-spam.md
@@ -15,8 +15,8 @@ The One-Man Spam filter targets spam coming from a single user. Instead of judgi
 
 ## Settings
 
-The filter supports the [settings shared by all filters](/chatbot/filters/#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
+The filter supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
 
 ## What happens on a violation
 
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation) for details.
+The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.

--- a/src/content/docs/chatbot/filters/paragraph.md
+++ b/src/content/docs/chatbot/filters/paragraph.md
@@ -20,8 +20,8 @@ The Paragraph filter helps manage the length of chat messages. It checks the num
 |---------|-------------|
 | Maximum amount | The maximum number of characters allowed in a message. If a message contains more characters than this limit, it will be flagged by the filter. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters/#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
 
 ## What happens on a violation
 
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation) for details.
+The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.

--- a/src/content/docs/chatbot/filters/repetition.md
+++ b/src/content/docs/chatbot/filters/repetition.md
@@ -15,8 +15,8 @@ The Repetition filter limits excessive repetition within a single chat message, 
 
 ## Settings
 
-The filter supports the [settings shared by all filters](/chatbot/filters/#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
+The filter supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
 
 ## What happens on a violation
 
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation) for details.
+The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.

--- a/src/content/docs/chatbot/filters/symbol.md
+++ b/src/content/docs/chatbot/filters/symbol.md
@@ -21,8 +21,8 @@ The Symbol filter helps manage the use of symbols in chat messages. It checks th
 | Minimum amount | The minimum number of symbols a message must have before the filter checks for a violation. If a message contains fewer symbols than this limit, it will not be checked by the filter. |
 | Maximum percent | The maximum percentage of a message that can be symbols. If the percentage of symbols in a message exceeds this limit, it will be flagged by the filter. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters/#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
 
 ## What happens on a violation
 
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation) for details.
+The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.

--- a/src/content/docs/chatbot/filters/zalgo.md
+++ b/src/content/docs/chatbot/filters/zalgo.md
@@ -15,8 +15,8 @@ The Zalgo filter removes "zalgo" text — messages distorted with stacked combin
 
 ## Settings
 
-The filter supports the [settings shared by all filters](/chatbot/filters/#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
+The filter supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
 
 ## What happens on a violation
 
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters/#what-happens-on-a-violation) for details.
+The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.

--- a/src/content/docs/chatbot/getting-started.mdx
+++ b/src/content/docs/chatbot/getting-started.mdx
@@ -36,12 +36,12 @@ Commands are the main way users will interact with the bot in your chat. They ca
 
 4. Optional: In the "Response Type" dropdown, select the method you would like the bot to use to send the response.
    - "Say" will send the response as a chat message as it is entered in the basic settings.
-   - "Mention" will send the response as a chat message, but will prefix the message with [`@$(user),`](/chatbot/variables/sender/).
+   - "Mention" will send the response as a chat message, but will prefix the message with [`@$(user),`](/chatbot/variables/sender).
    - "Reply" will send the response as a native reply to the user who triggered the command.
      - NOTE: If the platform does not support native replies, the response will be sent as a "Mention" instead.
    - "Whisper" will send the response as a whisper to the user who triggered the command.
 
-5. Add your desired response. For a list of all available variables, see the [variables documentation](/chatbot/variables/).
+5. Add your desired response. For a list of all available variables, see the [variables documentation](/chatbot/variables).
 
    ![Step 2](img/step_2.png "Step 2")
 
@@ -73,11 +73,11 @@ Timers allow you to automatically post announcements, social links, schedules, o
 
 </Steps>
 
-For the remaining settings — chat lines, multiple messages, and stream title or category conditions — see the [Timers](/chatbot/timers/) reference.
+For the remaining settings — chat lines, multiple messages, and stream title or category conditions — see the [Timers](/chatbot/timers) reference.
 
 ## Next steps
 
-- Learn more about creating and managing [custom commands](/chatbot/commands/custom/).
-- Browse all available [variables](/chatbot/variables/) you can use in responses.
-- Read the [Timers](/chatbot/timers/) reference for a full overview of timer settings.
-- Explore [Modules](/chatbot/modules/) and [Spam Filters](/chatbot/filters/) to take your chatbot further.
+- Learn more about creating and managing [custom commands](/chatbot/commands/custom).
+- Browse all available [variables](/chatbot/variables) you can use in responses.
+- Read the [Timers](/chatbot/timers) reference for a full overview of timer settings.
+- Explore [Modules](/chatbot/modules) and [Spam Filters](/chatbot/filters) to take your chatbot further.

--- a/src/content/docs/chatbot/index.mdx
+++ b/src/content/docs/chatbot/index.mdx
@@ -21,47 +21,47 @@ The StreamElements Chatbot is a chatbot for Twitch and YouTube Live. It provides
 <CardGrid>
   <LinkCard
     title="Getting Started"
-    href="/chatbot/getting-started/"
+    href="/chatbot/getting-started"
     description="Create your first custom command and timer."
   />
   <LinkCard
     title="Commands"
-    href="/chatbot/commands/"
+    href="/chatbot/commands"
     description="Default and custom chatbot commands."
   />
   <LinkCard
     title="Variables"
-    href="/chatbot/variables/"
+    href="/chatbot/variables"
     description="Dynamic values for command and timer responses."
   />
   <LinkCard
     title="Modules"
-    href="/chatbot/modules/"
+    href="/chatbot/modules"
     description="Interactive features for your chat."
   />
   <LinkCard
     title="Spam Filters"
-    href="/chatbot/filters/"
+    href="/chatbot/filters"
     description="Keep your chat clean and safe."
   />
   <LinkCard
     title="Timers"
-    href="/chatbot/timers/"
+    href="/chatbot/timers"
     description="Automated messages at regular intervals."
   />
   <LinkCard
     title="Quotes"
-    href="/chatbot/quotes/"
+    href="/chatbot/quotes"
     description="Save and share memorable moments from your stream."
   />
   <LinkCard
     title="Counters"
-    href="/chatbot/counters/"
+    href="/chatbot/counters"
     description="Keep track of deaths, misses, or any other event."
   />
   <LinkCard
     title="Troubleshooting"
-    href="/chatbot/troubleshooting/"
+    href="/chatbot/troubleshooting"
     description="Resolve common chatbot issues."
   />
 </CardGrid>

--- a/src/content/docs/chatbot/modules/bingo.md
+++ b/src/content/docs/chatbot/modules/bingo.md
@@ -64,4 +64,4 @@ The Emote Bingo module has the following settings in the StreamElements dashboar
 
 ## Related Commands
 
-- [`!bingo`](/chatbot/commands/default/bingo/): Starts an Emote Bingo game.
+- [`!bingo`](/chatbot/commands/default/bingo): Starts an Emote Bingo game.

--- a/src/content/docs/chatbot/modules/duel.md
+++ b/src/content/docs/chatbot/modules/duel.md
@@ -63,10 +63,10 @@ You can configure the following settings for the Duel module:
 
 ## Related Commands
 
-- [`!duel`](/chatbot/commands/default/duel/): Challenges another user to a duel.
-- [`!accept`](/chatbot/commands/default/accept/): Accepts a duel challenge.
-- [`!deny`](/chatbot/commands/default/deny/): Declines a duel challenge.
-- [`!cancelduel`](/chatbot/commands/default/cancelduel/): Cancels an outgoing duel request before it is accepted or denied.
+- [`!duel`](/chatbot/commands/default/duel): Challenges another user to a duel.
+- [`!accept`](/chatbot/commands/default/accept): Accepts a duel challenge.
+- [`!deny`](/chatbot/commands/default/deny): Declines a duel challenge.
+- [`!cancelduel`](/chatbot/commands/default/cancelduel): Cancels an outgoing duel request before it is accepted or denied.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/modules/eightball.mdx
+++ b/src/content/docs/chatbot/modules/eightball.mdx
@@ -63,7 +63,7 @@ If no responses are configured, the bot falls back to a default message saying t
 
 ## Related Commands
 
-- [`!8ball`](/chatbot/commands/default/8ball/): Asks the Magic 8 Ball a question.
+- [`!8ball`](/chatbot/commands/default/8ball): Asks the Magic 8 Ball a question.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/modules/index.mdx
+++ b/src/content/docs/chatbot/modules/index.mdx
@@ -31,21 +31,21 @@ Enable and configure each module in your StreamElements dashboard. Once enabled,
 ### Chat games
 
 <CardGrid>
-  <LinkCard title="Emote Bingo" href="/chatbot/modules/bingo/" description="An interactive chat game where players compete to identify the correct emote from a bingo card." />
-  <LinkCard title="Duel" href="/chatbot/modules/duel/" description="Let viewers challenge each other to a duel, wagering points for a chance to win." />
-  <LinkCard title="8ball" href="/chatbot/modules/eightball/" description="A Magic 8 Ball simulator that answers viewer questions with random responses." />
-  <LinkCard title="Emote Combo" href="/chatbot/modules/emotecombo/" description="Encourage viewers to build chains of consecutive emotes in chat." />
-  <LinkCard title="Emote Pyramid" href="/chatbot/modules/emotepyramid/" description="A collaborative chat game where viewers build pyramids of emotes." />
-  <LinkCard title="Raffle" href="/chatbot/modules/raffle/" description="Run raffles that viewers can join for a chance to win points." />
-  <LinkCard title="Roulette" href="/chatbot/modules/roulette/" description="A roulette-style gamble where viewers wager their points on a spin." />
-  <LinkCard title="Slotmachine" href="/chatbot/modules/slotmachine/" description="A virtual slot machine game where viewers wager points on matching emotes." />
-  <LinkCard title="Viewer Queue" href="/chatbot/modules/viewerqueue/" description="Create and manage a queue where viewers can join and be selected." />
-  <LinkCard title="Votekick" href="/chatbot/modules/votekick/" description="Let viewers vote on temporarily removing a user from chat." />
+  <LinkCard title="Emote Bingo" href="/chatbot/modules/bingo" description="An interactive chat game where players compete to identify the correct emote from a bingo card." />
+  <LinkCard title="Duel" href="/chatbot/modules/duel" description="Let viewers challenge each other to a duel, wagering points for a chance to win." />
+  <LinkCard title="8ball" href="/chatbot/modules/eightball" description="A Magic 8 Ball simulator that answers viewer questions with random responses." />
+  <LinkCard title="Emote Combo" href="/chatbot/modules/emotecombo" description="Encourage viewers to build chains of consecutive emotes in chat." />
+  <LinkCard title="Emote Pyramid" href="/chatbot/modules/emotepyramid" description="A collaborative chat game where viewers build pyramids of emotes." />
+  <LinkCard title="Raffle" href="/chatbot/modules/raffle" description="Run raffles that viewers can join for a chance to win points." />
+  <LinkCard title="Roulette" href="/chatbot/modules/roulette" description="A roulette-style gamble where viewers wager their points on a spin." />
+  <LinkCard title="Slotmachine" href="/chatbot/modules/slotmachine" description="A virtual slot machine game where viewers wager points on matching emotes." />
+  <LinkCard title="Viewer Queue" href="/chatbot/modules/viewerqueue" description="Create and manage a queue where viewers can join and be selected." />
+  <LinkCard title="Votekick" href="/chatbot/modules/votekick" description="Let viewers vote on temporarily removing a user from chat." />
 </CardGrid>
 
 ### Automation
 
 <CardGrid>
-  <LinkCard title="Chat Alerts" href="/chatbot/modules/chatalerts/" description="Automatically post messages in chat when stream events like follows, subscriptions, and raids occur." />
-  <LinkCard title="Live Announcement" href="/chatbot/modules/liveannouncement/" description="Automatically post a message in chat when your stream goes live." />
+  <LinkCard title="Chat Alerts" href="/chatbot/modules/chatalerts" description="Automatically post messages in chat when stream events like follows, subscriptions, and raids occur." />
+  <LinkCard title="Live Announcement" href="/chatbot/modules/liveannouncement" description="Automatically post a message in chat when your stream goes live." />
 </CardGrid>

--- a/src/content/docs/chatbot/modules/liveannouncement.md
+++ b/src/content/docs/chatbot/modules/liveannouncement.md
@@ -56,7 +56,7 @@ Each announcement message supports its own set of placeholders:
 
 Placeholders are only substituted in the announcement they belong to — for example, `{game}` is not replaced in the title change message.
 
-In addition to these placeholders, any standard [chat variable](/chatbot/variables/) also works in the announcement messages, such as `${channel.display_name}` or `${uptime}`.
+In addition to these placeholders, any standard [chat variable](/chatbot/variables) also works in the announcement messages, such as `${channel.display_name}` or `${uptime}`.
 
 ## Configuration
 

--- a/src/content/docs/chatbot/modules/raffle.mdx
+++ b/src/content/docs/chatbot/modules/raffle.mdx
@@ -59,13 +59,13 @@ The raffle messages can be customized in the StreamElements dashboard. The start
 
 ## Related Commands
 
-- [`!raffle`](/chatbot/commands/default/raffle/): Starts a multi-winner raffle.
-- [`!sraffle`](/chatbot/commands/default/sraffle/): Starts a single-winner raffle.
-- [`!join`](/chatbot/commands/default/join/): Used by viewers to enter an ongoing raffle for free.
-- [`!cancelraffle`](/chatbot/commands/default/cancelraffle/): Cancels the current raffle (moderators only).
+- [`!raffle`](/chatbot/commands/default/raffle): Starts a multi-winner raffle.
+- [`!sraffle`](/chatbot/commands/default/sraffle): Starts a single-winner raffle.
+- [`!join`](/chatbot/commands/default/join): Used by viewers to enter an ongoing raffle for free.
+- [`!cancelraffle`](/chatbot/commands/default/cancelraffle): Cancels the current raffle (moderators only).
 
 :::note
-[`!ticket`](/chatbot/commands/default/ticket/) is not part of the Raffle module — it is the entry command for [StreamElements Giveaways](/chatbot/commands/default/giveaway/), where tickets can cost loyalty points.
+[`!ticket`](/chatbot/commands/default/ticket) is not part of the Raffle module — it is the entry command for [StreamElements Giveaways](/chatbot/commands/default/giveaway), where tickets can cost loyalty points.
 :::
 
 ## FAQ

--- a/src/content/docs/chatbot/modules/roulette.md
+++ b/src/content/docs/chatbot/modules/roulette.md
@@ -77,12 +77,12 @@ Streamers can configure the Roulette module in the StreamElements dashboard with
 | All-in Win Message | The message shown when a user bets `all` and wins. |
 | All-in Lose Message | The message shown when a user bets `all` and loses. |
 
-See the [`!roulette` command reference](/chatbot/commands/default/roulette/) for the default message templates and available message variables.
+See the [`!roulette` command reference](/chatbot/commands/default/roulette) for the default message templates and available message variables.
 
 ## Related Commands
 
-- [`!roulette`](/chatbot/commands/default/roulette/): Initiates the roulette game.
-- [`!points`](/chatbot/commands/default/points/): Check your current point balance.
+- [`!roulette`](/chatbot/commands/default/roulette): Initiates the roulette game.
+- [`!points`](/chatbot/commands/default/points): Check your current point balance.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/modules/slotmachine.md
+++ b/src/content/docs/chatbot/modules/slotmachine.md
@@ -55,5 +55,5 @@ Streamers can customize the following settings for the Slotmachine module:
 
 ## Related Commands
 
-- [`!slots`](/chatbot/commands/default/slots/): Initiates the slot machine game.
-- [`!points`](/chatbot/commands/default/points/): Check your current point balance.
+- [`!slots`](/chatbot/commands/default/slots): Initiates the slot machine game.
+- [`!points`](/chatbot/commands/default/points): Check your current point balance.

--- a/src/content/docs/chatbot/modules/viewerqueue.mdx
+++ b/src/content/docs/chatbot/modules/viewerqueue.mdx
@@ -21,7 +21,7 @@ The Viewer Queue module allows streamers to create and manage a queue where view
 
 ## Usage
 
-Streamers and moderators manage the queue with `!queue` subcommands, while viewers join and check their place with their own set of subcommands. See the [`!queue` command reference](/chatbot/commands/default/queue/) for the full syntax of every subcommand.
+Streamers and moderators manage the queue with `!queue` subcommands, while viewers join and check their place with their own set of subcommands. See the [`!queue` command reference](/chatbot/commands/default/queue) for the full syntax of every subcommand.
 
 ## Examples
 
@@ -47,18 +47,18 @@ Streamers and moderators manage the queue with `!queue` subcommands, while viewe
 
 Viewer subcommands:
 
-- [`!queue join`](/chatbot/commands/default/queue/): Enter the open queue.
-- [`!queue position`](/chatbot/commands/default/queue/): Check your current position in the queue.
-- [`!queue list`](/chatbot/commands/default/queue/): List the next viewers waiting in the queue.
+- [`!queue join`](/chatbot/commands/default/queue): Enter the open queue.
+- [`!queue position`](/chatbot/commands/default/queue): Check your current position in the queue.
+- [`!queue list`](/chatbot/commands/default/queue): List the next viewers waiting in the queue.
 
 Moderator subcommands:
 
-- [`!queue open <title>`](/chatbot/commands/default/queue/): Open a queue with the given title for viewers to join.
-- [`!queue close`](/chatbot/commands/default/queue/): Close the queue, preventing new entries.
-- [`!queue pause`](/chatbot/commands/default/queue/): Temporarily stop viewers from joining.
-- [`!queue unpause`](/chatbot/commands/default/queue/): Resume allowing viewers to join.
-- [`!queue pick <username|random>`](/chatbot/commands/default/queue/): Select a specific user, or a random one, from the queue.
-- [`!queue remove <username>`](/chatbot/commands/default/queue/): Remove a specific user from the queue.
+- [`!queue open <title>`](/chatbot/commands/default/queue): Open a queue with the given title for viewers to join.
+- [`!queue close`](/chatbot/commands/default/queue): Close the queue, preventing new entries.
+- [`!queue pause`](/chatbot/commands/default/queue): Temporarily stop viewers from joining.
+- [`!queue unpause`](/chatbot/commands/default/queue): Resume allowing viewers to join.
+- [`!queue pick <username|random>`](/chatbot/commands/default/queue): Select a specific user, or a random one, from the queue.
+- [`!queue remove <username>`](/chatbot/commands/default/queue): Remove a specific user from the queue.
 
 ## Configuration
 

--- a/src/content/docs/chatbot/modules/votekick.md
+++ b/src/content/docs/chatbot/modules/votekick.md
@@ -66,4 +66,4 @@ The module's values come from the dashboard settings — customize the Votekick 
 
 ## Related Commands
 
-- [`!votekick`](/chatbot/commands/default/votekick/): Starts a vote to temporarily remove a user from chat.
+- [`!votekick`](/chatbot/commands/default/votekick): Starts a vote to temporarily remove a user from chat.

--- a/src/content/docs/chatbot/quotes.md
+++ b/src/content/docs/chatbot/quotes.md
@@ -91,7 +91,7 @@ Quotes can only be edited from the dashboard — there is no chat command for ed
 
 ## Chat Command Reference
 
-For the full command documentation, see the [!quote command reference](/chatbot/commands/default/quote/).
+For the full command documentation, see the [!quote command reference](/chatbot/commands/default/quote).
 
 | Command | Description | Permission |
 |---------|-------------|------------|
@@ -109,7 +109,7 @@ Editing quotes is dashboard-only; there is no `!quote edit` chat command.
 
 ## Quote Variables
 
-You can use quote variables in custom commands and timers. For detailed documentation, see the [$(quote) variable reference](/chatbot/variables/quote/).
+You can use quote variables in custom commands and timers. For detailed documentation, see the [$(quote) variable reference](/chatbot/variables/quote).
 
 - `$(quote)` - Returns a random quote
 - `$(quote <id>)` - Returns a specific quote by ID

--- a/src/content/docs/chatbot/timers.md
+++ b/src/content/docs/chatbot/timers.md
@@ -14,7 +14,7 @@ keywords:
 
 Chatbot timers are automated messages or actions that occur at specified intervals during a live stream. They serve to remind viewers about certain aspects of the stream, such as rules or upcoming events, and can also be used to automatically execute commands at regular intervals.
 
-You can manage your timers in the [StreamElements Dashboard](https://streamelements.com/dashboard/bot/timers). For a step-by-step walkthrough of creating your first timer, see [Getting Started](/chatbot/getting-started/).
+You can manage your timers in the [StreamElements Dashboard](https://streamelements.com/dashboard/bot/timers). For a step-by-step walkthrough of creating your first timer, see [Getting Started](/chatbot/getting-started).
 
 ## Settings
 

--- a/src/content/docs/chatbot/troubleshooting.md
+++ b/src/content/docs/chatbot/troubleshooting.md
@@ -15,24 +15,24 @@ This section helps you quickly resolve common issues you might encounter with th
 
 - Check that the bot is currently active in your channel. Go to your StreamElements dashboard and ensure the bot is turned on.
 - Ensure the bot is not banned or ignored in your channel. Sometimes the bot might have been accidentally banned, which prevents it from posting messages.
-- Check that the bot has not been muted with [`!bot mute`](/chatbot/commands/default/bot/). A muted bot sends no command responses or timer messages; use `!bot unmute` to restore it.
+- Check that the bot has not been muted with [`!bot mute`](/chatbot/commands/default/bot). A muted bot sends no command responses or timer messages; use `!bot unmute` to restore it.
 
 ## Commands not working
 
-- Verify the command syntax, including the prefix (usually `!`). See [Custom Commands](/chatbot/commands/custom/) for the management syntax.
-- Check the command's permission level. Some commands are restricted to moderators or the streamer; adjust this in the dashboard or with [`!command options`](/chatbot/commands/default/command/).
-- Check for cooldowns. If a command was recently used, it might still be on cooldown; cooldowns are configured per command with [`!command options`](/chatbot/commands/default/command/) or in the dashboard.
+- Verify the command syntax, including the prefix (usually `!`). See [Custom Commands](/chatbot/commands/custom) for the management syntax.
+- Check the command's permission level. Some commands are restricted to moderators or the streamer; adjust this in the dashboard or with [`!command options`](/chatbot/commands/default/command).
+- Check for cooldowns. If a command was recently used, it might still be on cooldown; cooldowns are configured per command with [`!command options`](/chatbot/commands/default/command) or in the dashboard.
 
 ## Timers not triggering
 
-- Ensure the timer is enabled and configured with the correct interval. See [Timers](/chatbot/timers/) for all settings.
-- Check the chat lines threshold. A timer only fires once the minimum number of chat messages has been sent within its interval, so it stays silent in an inactive chat. Lower the [chat lines setting](/chatbot/timers/) or wait for more chat activity.
-- Check any conditions on the timer. A timer with stream category or title keyword [conditions](/chatbot/timers/) only fires while those conditions are met.
+- Ensure the timer is enabled and configured with the correct interval. See [Timers](/chatbot/timers) for all settings.
+- Check the chat lines threshold. A timer only fires once the minimum number of chat messages has been sent within its interval, so it stays silent in an inactive chat. Lower the [chat lines setting](/chatbot/timers) or wait for more chat activity.
+- Check any conditions on the timer. A timer with stream category or title keyword [conditions](/chatbot/timers) only fires while those conditions are met.
 
 ## Messages being deleted
 
-- A spam filter is likely removing the messages. Review your settings for each filter in [Spam Filters](/chatbot/filters/).
-- If links are being deleted, the [Link filter](/chatbot/filters/links/) acts on messages containing links that are not on your allowlist. Add the link to the allowlist or exclude the affected user groups from the filter.
+- A spam filter is likely removing the messages. Review your settings for each filter in [Spam Filters](/chatbot/filters).
+- If links are being deleted, the [Link filter](/chatbot/filters/links) acts on messages containing links that are not on your allowlist. Add the link to the allowlist or exclude the affected user groups from the filter.
 
 ## FAQ
 
@@ -42,19 +42,19 @@ Go to the Chatbot section of your StreamElements dashboard and click the button 
 
 ### Can I create custom commands?
 
-Yes. You can define the command name, response, cooldowns, and user level restrictions. See [Custom Commands](/chatbot/commands/custom/) for managing commands from the dashboard or directly in chat, and [Getting Started](/chatbot/getting-started/) for a step-by-step walkthrough.
+Yes. You can define the command name, response, cooldowns, and user level restrictions. See [Custom Commands](/chatbot/commands/custom) for managing commands from the dashboard or directly in chat, and [Getting Started](/chatbot/getting-started) for a step-by-step walkthrough.
 
 ### How do I set up moderation filters?
 
-Filters for links, caps, symbols, and more can be set up in the StreamElements dashboard under the "Spam Filters" section. See [Spam Filters](/chatbot/filters/) for the available filters and their settings.
+Filters for links, caps, symbols, and more can be set up in the StreamElements dashboard under the "Spam Filters" section. See [Spam Filters](/chatbot/filters) for the available filters and their settings.
 
 ### Can the chatbot respond to commands with custom messages?
 
-Yes. Each custom command has a response you define, and responses can include [variables](/chatbot/variables/) for dynamic content. See [Custom Commands](/chatbot/commands/custom/).
+Yes. Each custom command has a response you define, and responses can include [variables](/chatbot/variables) for dynamic content. See [Custom Commands](/chatbot/commands/custom).
 
 ### How do I remove the chatbot from my channel?
 
-Use the [`!bot part`](/chatbot/commands/default/bot/) command in chat, or go to the Chatbot section in your StreamElements dashboard and select the option to part the bot from your channel.
+Use the [`!bot part`](/chatbot/commands/default/bot) command in chat, or go to the Chatbot section in your StreamElements dashboard and select the option to part the bot from your channel.
 
 ---
 

--- a/src/content/docs/chatbot/variables/7tvemotes.mdx
+++ b/src/content/docs/chatbot/variables/7tvemotes.mdx
@@ -32,8 +32,8 @@ When the command is triggered, the variable is replaced with a list of the chann
 
 ## Related Variables
 
-- [$(bttvemotes)](/chatbot/variables/bttvemotes/): Lists active BetterTTV emotes in the channel
-- [$(ffzemotes)](/chatbot/variables/ffzemotes/): Lists active FrankerFaceZ emotes in the channel
+- [$(bttvemotes)](/chatbot/variables/bttvemotes): Lists active BetterTTV emotes in the channel
+- [$(ffzemotes)](/chatbot/variables/ffzemotes): Lists active FrankerFaceZ emotes in the channel
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/ai.mdx
+++ b/src/content/docs/chatbot/variables/ai.mdx
@@ -57,7 +57,7 @@ Replace `<prompt>` with the text you want the AI to respond to. Everything you p
    !command add !aiwelcome ${ai Create a warm welcome message for ${1} who was last seen $(user.lastseen ${1}) ago. Their last message was $(user.lastmessage ${1}).}
    ```
 
-In these examples, `${1}` inserts only the first word the viewer types after the command, while `${1:}` inserts everything from the first word onward — see [Argument tokens](/chatbot/variables/args/) for details.
+In these examples, `${1}` inserts only the first word the viewer types after the command, while `${1:}` inserts everything from the first word onward — see [Argument tokens](/chatbot/variables/args) for details.
 
 ## Parameters
 

--- a/src/content/docs/chatbot/variables/args.mdx
+++ b/src/content/docs/chatbot/variables/args.mdx
@@ -113,9 +113,9 @@ The dot form also works for validators, e.g. `$(1.word)` or `$(1.emote)`.
 
 ## Related Variables
 
-- [`$(touser)`](/chatbot/variables/touser/): The first word after the command, falling back to the sender's name
-- [`$(sender)`](/chatbot/variables/sender/): The name of the user who triggered the command
-- [`$(user)`](/chatbot/variables/user/): Information about a user, such as points and rank
+- [`$(touser)`](/chatbot/variables/touser): The first word after the command, falling back to the sender's name
+- [`$(sender)`](/chatbot/variables/sender): The name of the user who triggered the command
+- [`$(user)`](/chatbot/variables/user): Information about a user, such as points and rank
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/bttvemotes.mdx
+++ b/src/content/docs/chatbot/variables/bttvemotes.mdx
@@ -32,8 +32,8 @@ When the command is triggered, the variable is replaced with a list of the chann
 
 ## Related Variables
 
-- [$(ffzemotes)](/chatbot/variables/ffzemotes/): Lists active FrankerFaceZ (FFZ) emotes in the channel
-- [$(7tvemotes)](/chatbot/variables/7tvemotes/): Lists active 7TV emotes in the channel
+- [$(ffzemotes)](/chatbot/variables/ffzemotes): Lists active FrankerFaceZ (FFZ) emotes in the channel
+- [$(7tvemotes)](/chatbot/variables/7tvemotes): Lists active 7TV emotes in the channel
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/channel.mdx
+++ b/src/content/docs/chatbot/variables/channel.mdx
@@ -63,7 +63,7 @@ $(channel somestreamer)
 - `$(channel.subs)` and `$(channel.subpoints)` always return `0` for other channels.
 - If the channel doesn't exist, `title` and `game` return `<error not_found>`; other lookup failures return an `<error ...>` code.
 
-The standalone [`$(game)`](/chatbot/variables/game/), [`$(title)`](/chatbot/variables/title/), and [`$(uptime)`](/chatbot/variables/uptime/) variables are shortcuts for the matching channel fields and accept a username the same way.
+The standalone [`$(game)`](/chatbot/variables/game), [`$(title)`](/chatbot/variables/title), and [`$(uptime)`](/chatbot/variables/uptime) variables are shortcuts for the matching channel fields and accept a username the same way.
 
 ## Examples
 
@@ -102,9 +102,9 @@ The standalone [`$(game)`](/chatbot/variables/game/), [`$(title)`](/chatbot/vari
 
 ## Related Variables
 
-- [$(user)](/chatbot/variables/user/): Displays information about the user who triggered the command
-- [$(touser)](/chatbot/variables/touser/): Refers to the target user in commands that mention other users
-- [$(game)](/chatbot/variables/game/), [$(title)](/chatbot/variables/title/), [$(uptime)](/chatbot/variables/uptime/): Standalone shortcuts for the matching channel fields
+- [$(user)](/chatbot/variables/user): Displays information about the user who triggered the command
+- [$(touser)](/chatbot/variables/touser): Refers to the target user in commands that mention other users
+- [$(game)](/chatbot/variables/game), [$(title)](/chatbot/variables/title), [$(uptime)](/chatbot/variables/uptime): Standalone shortcuts for the matching channel fields
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/cheat-sheet.mdx
+++ b/src/content/docs/chatbot/variables/cheat-sheet.mdx
@@ -18,76 +18,76 @@ Every chatbot variable on one page — syntax and what it returns, at a glance. 
 
 | Variable | Syntax | Returns |
 | --- | --- | --- |
-| [`$(channel)`](/chatbot/variables/channel/) | `$(channel.<field> [channel])` | A channel field (see [sub-variables](#channel-sub-variables)); bare `$(channel)` returns the channel name. |
-| [`$(game)`](/chatbot/variables/game/) | `$(game [channel])` | The current category, e.g. `Just Chatting`; `<no game>` when unset. |
-| [`$(title)`](/chatbot/variables/title/) | `$(title [channel])` | The current stream title. Alias: `$(status)`. |
-| [`$(uptime)`](/chatbot/variables/uptime/) | `$(uptime [channel])` | Time live, e.g. `2 hours 30 mins`; `<not live>` when offline. |
-| [`$(provider)`](/chatbot/variables/provider/) | `$(provider)` | The platform slug: `twitch`, `youtube`, `trovo`, or `kick`. |
+| [`$(channel)`](/chatbot/variables/channel) | `$(channel.<field> [channel])` | A channel field (see [sub-variables](#channel-sub-variables)); bare `$(channel)` returns the channel name. |
+| [`$(game)`](/chatbot/variables/game) | `$(game [channel])` | The current category, e.g. `Just Chatting`; `<no game>` when unset. |
+| [`$(title)`](/chatbot/variables/title) | `$(title [channel])` | The current stream title. Alias: `$(status)`. |
+| [`$(uptime)`](/chatbot/variables/uptime) | `$(uptime [channel])` | Time live, e.g. `2 hours 30 mins`; `<not live>` when offline. |
+| [`$(provider)`](/chatbot/variables/provider) | `$(provider)` | The platform slug: `twitch`, `youtube`, `trovo`, or `kick`. |
 
 ## Stream management
 
 | Variable | Syntax | Returns |
 | --- | --- | --- |
-| [`$(setgame)`](/chatbot/variables/setgame/) | `$(setgame "<game>")` | Sets the stream category. |
-| [`$(settitle)`](/chatbot/variables/settitle/) | `$(settitle "<title>")` | Sets the stream title. |
+| [`$(setgame)`](/chatbot/variables/setgame) | `$(setgame "<game>")` | Sets the stream category. |
+| [`$(settitle)`](/chatbot/variables/settitle) | `$(settitle "<title>")` | Sets the stream title. |
 
 ## User & chat
 
 | Variable | Syntax | Returns |
 | --- | --- | --- |
-| [`$(user)`](/chatbot/variables/user/) | `$(user.<field> [username])` | A user field (see [sub-variables](#user-and-sender-sub-variables)); bare `$(user)` returns the display name. |
-| [`$(sender)`](/chatbot/variables/sender/) | `$(sender.<field>)` | Same fields as `$(user)`, always for the message author. Alias: `$(source)`. |
-| [`$(touser)`](/chatbot/variables/touser/) | `$(touser)` | The first word after the command, or the sender's display name. |
-| [`$(1)`, `$(1:)`](/chatbot/variables/args/) | `$(N)` `$(N:)` `$(N:M)` | Words of the triggering message (see [argument tokens](#argument-tokens)). |
-| [`$(msgid)`](/chatbot/variables/msgid/) | `$(msgid)` | The platform message ID of the triggering message. |
-| [`$(pointsname)`](/chatbot/variables/pointsname/) | `$(pointsname)` | The channel's loyalty points name; `points` when unset. |
-| [`$(redeem)`](/chatbot/variables/redeem/) | `$(redeem [item] [input])` | Redeems a loyalty store item; the bot replies with the store message. |
+| [`$(user)`](/chatbot/variables/user) | `$(user.<field> [username])` | A user field (see [sub-variables](#user-and-sender-sub-variables)); bare `$(user)` returns the display name. |
+| [`$(sender)`](/chatbot/variables/sender) | `$(sender.<field>)` | Same fields as `$(user)`, always for the message author. Alias: `$(source)`. |
+| [`$(touser)`](/chatbot/variables/touser) | `$(touser)` | The first word after the command, or the sender's display name. |
+| [`$(1)`, `$(1:)`](/chatbot/variables/args) | `$(N)` `$(N:)` `$(N:M)` | Words of the triggering message (see [argument tokens](#argument-tokens)). |
+| [`$(msgid)`](/chatbot/variables/msgid) | `$(msgid)` | The platform message ID of the triggering message. |
+| [`$(pointsname)`](/chatbot/variables/pointsname) | `$(pointsname)` | The channel's loyalty points name; `points` when unset. |
+| [`$(redeem)`](/chatbot/variables/redeem) | `$(redeem [item] [input])` | Redeems a loyalty store item; the bot replies with the store message. |
 
 ## Emotes
 
 | Variable | Syntax | Returns |
 | --- | --- | --- |
-| [`$(twitchemotes)`](/chatbot/variables/twitchemotes/) | `$(twitchemotes)` | The channel's Twitch subscriber emote codes, space-separated. |
-| [`$(bttvemotes)`](/chatbot/variables/bttvemotes/) | `$(bttvemotes)` | The channel's active BetterTTV emote codes. |
-| [`$(ffzemotes)`](/chatbot/variables/ffzemotes/) | `$(ffzemotes)` | The channel's active FrankerFaceZ emote codes. |
-| [`$(7tvemotes)`](/chatbot/variables/7tvemotes/) | `$(7tvemotes)` | The channel's active 7TV emote codes. |
+| [`$(twitchemotes)`](/chatbot/variables/twitchemotes) | `$(twitchemotes)` | The channel's Twitch subscriber emote codes, space-separated. |
+| [`$(bttvemotes)`](/chatbot/variables/bttvemotes) | `$(bttvemotes)` | The channel's active BetterTTV emote codes. |
+| [`$(ffzemotes)`](/chatbot/variables/ffzemotes) | `$(ffzemotes)` | The channel's active FrankerFaceZ emote codes. |
+| [`$(7tvemotes)`](/chatbot/variables/7tvemotes) | `$(7tvemotes)` | The channel's active 7TV emote codes. |
 
 ## Counters & data
 
 | Variable | Syntax | Returns |
 | --- | --- | --- |
-| [`$(count)`](/chatbot/variables/count/) | `$(count [name] [modifier])` | Changes a counter and returns the new value; `+N`/`-N` adjusts, a bare number sets. |
-| [`$(getcount)`](/chatbot/variables/getcount/) | `$(getcount <name>)` | The counter's value without changing it. |
-| [`$(quote)`](/chatbot/variables/quote/) | `$(quote [id])` | A saved quote as `#12 <text>`; random when no id; `quote not found` on a bad id. |
+| [`$(count)`](/chatbot/variables/count) | `$(count [name] [modifier])` | Changes a counter and returns the new value; `+N`/`-N` adjusts, a bare number sets. |
+| [`$(getcount)`](/chatbot/variables/getcount) | `$(getcount <name>)` | The counter's value without changing it. |
+| [`$(quote)`](/chatbot/variables/quote) | `$(quote [id])` | A saved quote as `#12 <text>`; random when no id; `quote not found` on a bad id. |
 
 ## Games
 
 | Variable | Syntax | Returns |
 | --- | --- | --- |
-| [`$(leagueoflegends)`](/chatbot/variables/leagueoflegends/) | `$(leagueoflegends <name#tag> <server>)` | The player's LoL rank, e.g. `Gold IV (81 LP)`. |
-| [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics/) | `$(teamfighttactics <region> <name#tag>)` | The player's TFT rank, e.g. `Gold IV (81 LP)`; `Unranked` on errors. Alias: `$(tft)`. |
-| [`$(pubg)`](/chatbot/variables/pubg/) | `$(pubg <region> <user> <matchType> <stat>)` | A PUBG stat from pubgtracker.com, e.g. `248`. |
+| [`$(leagueoflegends)`](/chatbot/variables/leagueoflegends) | `$(leagueoflegends <name#tag> <server>)` | The player's LoL rank, e.g. `Gold IV (81 LP)`. |
+| [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics) | `$(teamfighttactics <region> <name#tag>)` | The player's TFT rank, e.g. `Gold IV (81 LP)`; `Unranked` on errors. Alias: `$(tft)`. |
+| [`$(pubg)`](/chatbot/variables/pubg) | `$(pubg <region> <user> <matchType> <stat>)` | A PUBG stat from pubgtracker.com, e.g. `248`. |
 
 ## Logic, utility & web
 
 | Variable | Syntax | Returns |
 | --- | --- | --- |
-| [`$(if)`](/chatbot/variables/if/) | `$(if <condition> <then> [else])` | `<then>` when the condition is true, otherwise `[else]`; false with no else suppresses the whole reply. |
-| [`$(math)`](/chatbot/variables/math/) | `$(math <expression>)` | The result of the calculation, e.g. `7.8`. |
-| [`$(time)`](/chatbot/variables/time/) | `$(time [timezone])` | The current time as 24-hour `HH:MM`; UTC when no IANA zone is given. |
-| [`$(time.until)`](/chatbot/variables/time/) | `$(time.until <HH:MM>)` | Time until (or since) the given time, e.g. `2 hours 30 mins` (with ` ago` if past). |
-| [`$(repeat)`](/chatbot/variables/repeat/) | `$(repeat <count> <phrase>)` | The phrase repeated, space-separated (capped at 100 repeats / ~1000 characters). |
-| [`$(random)`](/chatbot/variables/random/) | `$(random)` / `$(random.X-Y)` | A random integer, 1–100 by default (see [random forms](#random-forms)). |
-| [`$(customapi)`](/chatbot/variables/customapi/) | `$(customapi <url>)` | The first 400 bytes of the URL's response. Alias: `$(urlfetch)`. |
-| [`$(queryescape)`](/chatbot/variables/queryescape/) | `$(queryescape <text>)` | The text URL-query-encoded (spaces become `+`). Alias: `$(queryencode)`. |
-| [`$(pathescape)`](/chatbot/variables/pathescape/) | `$(pathescape <text>)` | The text URL-path-encoded (spaces become `%20`). Alias: `$(pathencode)`. |
-| [`$(weather)`](/chatbot/variables/weather/) | `$(weather "<location>")` | Current conditions: temperature, wind, humidity, visibility, pressure. |
-| [`$(stockprice)`](/chatbot/variables/stockprice/) | `$(stockprice <symbol>)` | A real-time stock price line for the symbol. |
-| [`$(ai)`](/chatbot/variables/ai/) | `$(ai <prompt>)` | An AI-generated reply (prompt up to 512 characters). Alias: `$(chatgpt)`. |
+| [`$(if)`](/chatbot/variables/if) | `$(if <condition> <then> [else])` | `<then>` when the condition is true, otherwise `[else]`; false with no else suppresses the whole reply. |
+| [`$(math)`](/chatbot/variables/math) | `$(math <expression>)` | The result of the calculation, e.g. `7.8`. |
+| [`$(time)`](/chatbot/variables/time) | `$(time [timezone])` | The current time as 24-hour `HH:MM`; UTC when no IANA zone is given. |
+| [`$(time.until)`](/chatbot/variables/time) | `$(time.until <HH:MM>)` | Time until (or since) the given time, e.g. `2 hours 30 mins` (with ` ago` if past). |
+| [`$(repeat)`](/chatbot/variables/repeat) | `$(repeat <count> <phrase>)` | The phrase repeated, space-separated (capped at 100 repeats / ~1000 characters). |
+| [`$(random)`](/chatbot/variables/random) | `$(random)` / `$(random.X-Y)` | A random integer, 1–100 by default (see [random forms](#random-forms)). |
+| [`$(customapi)`](/chatbot/variables/customapi) | `$(customapi <url>)` | The first 400 bytes of the URL's response. Alias: `$(urlfetch)`. |
+| [`$(queryescape)`](/chatbot/variables/queryescape) | `$(queryescape <text>)` | The text URL-query-encoded (spaces become `+`). Alias: `$(queryencode)`. |
+| [`$(pathescape)`](/chatbot/variables/pathescape) | `$(pathescape <text>)` | The text URL-path-encoded (spaces become `%20`). Alias: `$(pathencode)`. |
+| [`$(weather)`](/chatbot/variables/weather) | `$(weather "<location>")` | Current conditions: temperature, wind, humidity, visibility, pressure. |
+| [`$(stockprice)`](/chatbot/variables/stockprice) | `$(stockprice <symbol>)` | A real-time stock price line for the symbol. |
+| [`$(ai)`](/chatbot/variables/ai) | `$(ai <prompt>)` | An AI-generated reply (prompt up to 512 characters). Alias: `$(chatgpt)`. |
 
 ## Argument tokens
 
-Words are numbered from the start of the triggering message; **word 0 is the command trigger itself**. See the [argument tokens page](/chatbot/variables/args/) for details.
+Words are numbered from the start of the triggering message; **word 0 is the command trigger itself**. See the [argument tokens page](/chatbot/variables/args) for details.
 
 | Token | Returns |
 | --- | --- |

--- a/src/content/docs/chatbot/variables/count.mdx
+++ b/src/content/docs/chatbot/variables/count.mdx
@@ -79,7 +79,7 @@ Counters are automatically created when first used and persist across stream ses
 
 ## Related Variables
 
-- [`$(getcount)`](/chatbot/variables/getcount/): Display the current value of a counter
+- [`$(getcount)`](/chatbot/variables/getcount): Display the current value of a counter
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/customapi.mdx
+++ b/src/content/docs/chatbot/variables/customapi.mdx
@@ -47,7 +47,7 @@ The legacy dot form is also supported: `$(customapi.https://example.com/data)` w
 - You cannot set custom request headers.
 - Responses are truncated to the **first 400 bytes**; anything longer is silently cut off.
 - Query parameters are percent-encoded and re-sorted alphabetically before the request is made.
-- The URL must be a single token without spaces — all inputs are concatenated with no separator, so spaces are dropped. To insert dynamic values like user input into a URL, encode them first with [`$(queryescape)`](/chatbot/variables/queryescape/).
+- The URL must be a single token without spaces — all inputs are concatenated with no separator, so spaces are dropped. To insert dynamic values like user input into a URL, encode them first with [`$(queryescape)`](/chatbot/variables/queryescape).
 - There is no caching: every evaluation makes a fresh request.
 
 ## Examples

--- a/src/content/docs/chatbot/variables/ffzemotes.mdx
+++ b/src/content/docs/chatbot/variables/ffzemotes.mdx
@@ -32,8 +32,8 @@ When the command is triggered, the variable is replaced with a list of the chann
 
 ## Related Variables
 
-- [$(bttvemotes)](/chatbot/variables/bttvemotes/): Lists active BetterTTV emotes in the channel
-- [$(7tvemotes)](/chatbot/variables/7tvemotes/): Lists active 7TV emotes in the channel
+- [$(bttvemotes)](/chatbot/variables/bttvemotes): Lists active BetterTTV emotes in the channel
+- [$(7tvemotes)](/chatbot/variables/7tvemotes): Lists active 7TV emotes in the channel
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/game.mdx
+++ b/src/content/docs/chatbot/variables/game.mdx
@@ -17,7 +17,7 @@ import ChatExample from '@components/ChatExample.astro';
 The `$(game)` variable is a powerful tool that allows you to display the current game being played on a Twitch channel. This variable is particularly useful for creating dynamic commands or messages that reference the streamer's current activity.
 
 :::note
-`$(game)` is not available on YouTube — there, it renders as literal text instead of being replaced. On YouTube, use [`$(channel.game)`](/chatbot/variables/channel/) instead, which works on every platform.
+`$(game)` is not available on YouTube — there, it renders as literal text instead of being replaced. On YouTube, use [`$(channel.game)`](/chatbot/variables/channel) instead, which works on every platform.
 :::
 
 ## Use it
@@ -63,9 +63,9 @@ Output: `shroud is playing: Counter-Strike: Global Offensive`
 
 ## Related Variables
 
-- [`$(title)`](/chatbot/variables/title/): Displays the current stream title
-- [`$(channel)`](/chatbot/variables/channel/): Shows information about the current channel
-- [`$(uptime)`](/chatbot/variables/uptime/): Displays how long the current stream has been live
+- [`$(title)`](/chatbot/variables/title): Displays the current stream title
+- [`$(channel)`](/chatbot/variables/channel): Shows information about the current channel
+- [`$(uptime)`](/chatbot/variables/uptime): Displays how long the current stream has been live
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/getcount.mdx
+++ b/src/content/docs/chatbot/variables/getcount.mdx
@@ -53,12 +53,12 @@ The `$(getcount)` variable takes one parameter:
 - `counter_name`: The name of the counter you want to retrieve the value for. This is a required parameter.
 
 :::note
-Unlike [`$(count)`](/chatbot/variables/count/), `$(getcount)` is read-only and never modifies the counter — and it does not fall back to the invoking command's own counter, so the counter name must always be provided.
+Unlike [`$(count)`](/chatbot/variables/count), `$(getcount)` is read-only and never modifies the counter — and it does not fall back to the invoking command's own counter, so the counter name must always be provided.
 :::
 
 ## Related Variables
 
-- [`$(count)`](/chatbot/variables/count/): Increments a counter and returns its new value
+- [`$(count)`](/chatbot/variables/count): Increments a counter and returns its new value
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/if.mdx
+++ b/src/content/docs/chatbot/variables/if.mdx
@@ -80,9 +80,9 @@ A practical pattern is gating on another variable that produces a boolean-like v
 
 ## Related variables
 
-- [`$(random)`](/chatbot/variables/random/): `$(random.pick 1,0)` makes a 50/50 condition for `$(if)`.
-- [`$(provider)`](/chatbot/variables/provider/): Returns the channel's platform slug.
-- [`$(1)`, `$(1:)`](/chatbot/variables/args/): Argument tokens and pipe defaults, useful inside `$(if)` branches.
+- [`$(random)`](/chatbot/variables/random): `$(random.pick 1,0)` makes a 50/50 condition for `$(if)`.
+- [`$(provider)`](/chatbot/variables/provider): Returns the channel's platform slug.
+- [`$(1)`, `$(1:)`](/chatbot/variables/args): Argument tokens and pipe defaults, useful inside `$(if)` branches.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/index.md
+++ b/src/content/docs/chatbot/variables/index.md
@@ -19,7 +19,7 @@ For example, in the command `$(uptime shroud)`, `shroud` is a variable represent
 Variables make chat commands more flexible and powerful, allowing for a wide range of interactions and functionalities.
 
 :::tip[In a hurry?]
-See the [Variables cheat sheet](/chatbot/variables/cheat-sheet/) — every variable with its syntax and return value on a single page.
+See the [Variables cheat sheet](/chatbot/variables/cheat-sheet) — every variable with its syntax and return value on a single page.
 :::
 
 :::note
@@ -34,73 +34,73 @@ Variables work on all platforms unless a page notes otherwise — on YouTube, `$
 
 | Variable | Description |
 | --- | --- |
-| [`$(channel)`](/chatbot/variables/channel/) | Channel information such as name, viewer count, followers, and subscribers. |
-| [`$(game)`](/chatbot/variables/game/) | Display the current game on a Twitch channel. |
-| [`$(title)`](/chatbot/variables/title/) | Display a channel's title. Also available as `$(status)`. |
-| [`$(uptime)`](/chatbot/variables/uptime/) | Display stream uptime for any channel. |
-| [`$(provider)`](/chatbot/variables/provider/) | Display the platform the channel runs on: `twitch`, `youtube`, `trovo`, or `kick`. |
+| [`$(channel)`](/chatbot/variables/channel) | Channel information such as name, viewer count, followers, and subscribers. |
+| [`$(game)`](/chatbot/variables/game) | Display the current game on a Twitch channel. |
+| [`$(title)`](/chatbot/variables/title) | Display a channel's title. Also available as `$(status)`. |
+| [`$(uptime)`](/chatbot/variables/uptime) | Display stream uptime for any channel. |
+| [`$(provider)`](/chatbot/variables/provider) | Display the platform the channel runs on: `twitch`, `youtube`, `trovo`, or `kick`. |
 
 ## Stream Management
 
 | Variable | Description |
 | --- | --- |
-| [`$(setgame)`](/chatbot/variables/setgame/) | Change the stream's game category. |
-| [`$(settitle)`](/chatbot/variables/settitle/) | Change the stream title. |
+| [`$(setgame)`](/chatbot/variables/setgame) | Change the stream's game category. |
+| [`$(settitle)`](/chatbot/variables/settitle) | Change the stream title. |
 
 ## User & Chat
 
 | Variable | Description |
 | --- | --- |
-| [`$(user)`](/chatbot/variables/user/) | User information such as name, points, and rank; accepts a username argument. |
-| [`$(sender)`](/chatbot/variables/sender/) | Information about the user who triggered the command. Also available as `$(source)`. |
-| [`$(touser)`](/chatbot/variables/touser/) | Display a user's name or a specified word. |
-| [`$(1)`, `$(1:)`](/chatbot/variables/args/) | Access the words of the message that triggered the command. |
-| [`$(msgid)`](/chatbot/variables/msgid/) | Retrieve the unique message ID. |
-| [`$(pointsname)`](/chatbot/variables/pointsname/) | Display the channel's custom loyalty points name. |
-| [`$(redeem)`](/chatbot/variables/redeem/) | Redeem a loyalty store item straight from a chat command. |
+| [`$(user)`](/chatbot/variables/user) | User information such as name, points, and rank; accepts a username argument. |
+| [`$(sender)`](/chatbot/variables/sender) | Information about the user who triggered the command. Also available as `$(source)`. |
+| [`$(touser)`](/chatbot/variables/touser) | Display a user's name or a specified word. |
+| [`$(1)`, `$(1:)`](/chatbot/variables/args) | Access the words of the message that triggered the command. |
+| [`$(msgid)`](/chatbot/variables/msgid) | Retrieve the unique message ID. |
+| [`$(pointsname)`](/chatbot/variables/pointsname) | Display the channel's custom loyalty points name. |
+| [`$(redeem)`](/chatbot/variables/redeem) | Redeem a loyalty store item straight from a chat command. |
 
 ## Emotes
 
 | Variable | Description |
 | --- | --- |
-| [`$(twitchemotes)`](/chatbot/variables/twitchemotes/) | Display available Twitch subscriber emotes. |
-| [`$(bttvemotes)`](/chatbot/variables/bttvemotes/) | Display active BetterTTV emotes in the channel. |
-| [`$(ffzemotes)`](/chatbot/variables/ffzemotes/) | Display active FrankerFaceZ emotes in the channel. |
-| [`$(7tvemotes)`](/chatbot/variables/7tvemotes/) | List active 7TV emotes in the channel. |
+| [`$(twitchemotes)`](/chatbot/variables/twitchemotes) | Display available Twitch subscriber emotes. |
+| [`$(bttvemotes)`](/chatbot/variables/bttvemotes) | Display active BetterTTV emotes in the channel. |
+| [`$(ffzemotes)`](/chatbot/variables/ffzemotes) | Display active FrankerFaceZ emotes in the channel. |
+| [`$(7tvemotes)`](/chatbot/variables/7tvemotes) | List active 7TV emotes in the channel. |
 
 ## Counters & Data
 
 | Variable | Description |
 | --- | --- |
-| [`$(count)`](/chatbot/variables/count/) | Create and manage custom counters. |
-| [`$(getcount)`](/chatbot/variables/getcount/) | Retrieve a counter value without incrementing it. |
-| [`$(quote)`](/chatbot/variables/quote/) | Display random or specific saved quotes. |
+| [`$(count)`](/chatbot/variables/count) | Create and manage custom counters. |
+| [`$(getcount)`](/chatbot/variables/getcount) | Retrieve a counter value without incrementing it. |
+| [`$(quote)`](/chatbot/variables/quote) | Display random or specific saved quotes. |
 
 ## Games
 
 | Variable | Description |
 | --- | --- |
-| [`$(leagueoflegends)`](/chatbot/variables/leagueoflegends/) | Get a League of Legends player's rank and LP. |
-| [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics/) | Get a Teamfight Tactics player's rank and LP. Also available as `$(tft)`. |
-| [`$(pubg)`](/chatbot/variables/pubg/) | Display PUBG player statistics like K/D, wins, and rating. |
+| [`$(leagueoflegends)`](/chatbot/variables/leagueoflegends) | Get a League of Legends player's rank and LP. |
+| [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics) | Get a Teamfight Tactics player's rank and LP. Also available as `$(tft)`. |
+| [`$(pubg)`](/chatbot/variables/pubg) | Display PUBG player statistics like K/D, wins, and rating. |
 
 ## Utility & Web
 
 | Variable | Description |
 | --- | --- |
-| [`$(if)`](/chatbot/variables/if/) | Show different responses depending on a true/false condition. |
-| [`$(customapi)`](/chatbot/variables/customapi/) | Make an API request and display the response in chat. Also available as `$(urlfetch)`. |
-| [`$(math)`](/chatbot/variables/math/) | Perform mathematical calculations in chat messages. |
-| [`$(time)`](/chatbot/variables/time/) | Display the current time in a timezone, or a countdown. |
-| [`$(queryescape)`](/chatbot/variables/queryescape/) | Encode a string for use in a URL query. Also available as `$(queryencode)`. |
-| [`$(pathescape)`](/chatbot/variables/pathescape/) | Escape a string for use in a URL path. Also available as `$(pathencode)`. |
-| [`$(weather)`](/chatbot/variables/weather/) | Display current weather conditions for a location. |
-| [`$(stockprice)`](/chatbot/variables/stockprice/) | Display real-time stock prices. |
-| [`$(repeat)`](/chatbot/variables/repeat/) | Repeat a phrase a specified number of times. |
+| [`$(if)`](/chatbot/variables/if) | Show different responses depending on a true/false condition. |
+| [`$(customapi)`](/chatbot/variables/customapi) | Make an API request and display the response in chat. Also available as `$(urlfetch)`. |
+| [`$(math)`](/chatbot/variables/math) | Perform mathematical calculations in chat messages. |
+| [`$(time)`](/chatbot/variables/time) | Display the current time in a timezone, or a countdown. |
+| [`$(queryescape)`](/chatbot/variables/queryescape) | Encode a string for use in a URL query. Also available as `$(queryencode)`. |
+| [`$(pathescape)`](/chatbot/variables/pathescape) | Escape a string for use in a URL path. Also available as `$(pathencode)`. |
+| [`$(weather)`](/chatbot/variables/weather) | Display current weather conditions for a location. |
+| [`$(stockprice)`](/chatbot/variables/stockprice) | Display real-time stock prices. |
+| [`$(repeat)`](/chatbot/variables/repeat) | Repeat a phrase a specified number of times. |
 
 ## Fun
 
 | Variable | Description |
 | --- | --- |
-| [`$(ai)`](/chatbot/variables/ai/) | Generate AI responses in chat. Also available as `$(chatgpt)`. |
-| [`$(random)`](/chatbot/variables/random/) | Generate random numbers, emotes, or chatters. |
+| [`$(ai)`](/chatbot/variables/ai) | Generate AI responses in chat. Also available as `$(chatgpt)`. |
+| [`$(random)`](/chatbot/variables/random) | Generate random numbers, emotes, or chatters. |

--- a/src/content/docs/chatbot/variables/leagueoflegends.mdx
+++ b/src/content/docs/chatbot/variables/leagueoflegends.mdx
@@ -82,7 +82,7 @@ Challenger I (1229 LP)
 
 ## Related Variables
 
-- [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics/): The same rank lookup for Teamfight Tactics
+- [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics): The same rank lookup for Teamfight Tactics
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/math.mdx
+++ b/src/content/docs/chatbot/variables/math.mdx
@@ -78,7 +78,7 @@ Invalid expressions return the error text produced by the math service itself.
 
 ## Related Variables
 
-- [`$(customapi)`](/chatbot/variables/customapi/): Can be used to fetch and process numerical data from external sources
+- [`$(customapi)`](/chatbot/variables/customapi): Can be used to fetch and process numerical data from external sources
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/msgid.mdx
+++ b/src/content/docs/chatbot/variables/msgid.mdx
@@ -32,8 +32,8 @@ To use the `$(msgid)` variable, simply include it in your command response or cu
 
 ## Related Variables
 
-- [`$(user)`](/chatbot/variables/user/): Returns the username of the person who triggered the command
-- [`$(channel)`](/chatbot/variables/channel/): Returns the name of the channel where the command was triggered
+- [`$(user)`](/chatbot/variables/user): Returns the username of the person who triggered the command
+- [`$(channel)`](/chatbot/variables/channel): Returns the name of the channel where the command was triggered
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/pathescape.mdx
+++ b/src/content/docs/chatbot/variables/pathescape.mdx
@@ -81,8 +81,8 @@ If no text is provided, the variable is not replaced and appears as literal text
 
 ## Related Variables
 
-- [`$(queryescape)`](/chatbot/variables/queryescape/): Escapes text for use in URL query parameters (encodes spaces as `+`).
-- [`$(customapi)`](/chatbot/variables/customapi/): Fetches content from a URL, often combined with `$(pathescape)` for dynamic requests.
+- [`$(queryescape)`](/chatbot/variables/queryescape): Escapes text for use in URL query parameters (encodes spaces as `+`).
+- [`$(customapi)`](/chatbot/variables/customapi): Fetches content from a URL, often combined with `$(pathescape)` for dynamic requests.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/pointsname.mdx
+++ b/src/content/docs/chatbot/variables/pointsname.mdx
@@ -45,9 +45,9 @@ Earn more memecoins by watching the stream!
 
 ## Related
 
-- [`$(user.points)`](/chatbot/variables/user/#available-variables): Displays the user's current loyalty points balance
-- [`!addpoints`](/chatbot/commands/default/addpoints/): Adds points to a user's balance (mod/broadcaster only)
-- [`!setpoints`](/chatbot/commands/default/setpoints/): Sets a user's points to a specific value (mod/broadcaster only)
+- [`$(user.points)`](/chatbot/variables/user#available-variables): Displays the user's current loyalty points balance
+- [`!addpoints`](/chatbot/commands/default/addpoints): Adds points to a user's balance (mod/broadcaster only)
+- [`!setpoints`](/chatbot/commands/default/setpoints): Sets a user's points to a specific value (mod/broadcaster only)
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/provider.mdx
+++ b/src/content/docs/chatbot/variables/provider.mdx
@@ -16,7 +16,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(provider)` variable returns the platform the channel runs on, as a lowercase slug: `twitch`, `youtube`, `trovo`, or `kick`. It is identical to [`$(channel.provider)`](/chatbot/variables/channel/) and works on every platform.
+The `$(provider)` variable returns the platform the channel runs on, as a lowercase slug: `twitch`, `youtube`, `trovo`, or `kick`. It is identical to [`$(channel.provider)`](/chatbot/variables/channel) and works on every platform.
 
 ## Use it
 
@@ -44,7 +44,7 @@ The variable takes no arguments and always refers to the channel the bot is runn
 | Trovo | `trovo` |
 | Kick | `kick` |
 
-Because the output is a stable lowercase slug, it is most useful **nested inside other variables** — for example to build platform-aware responses with [`$(customapi)`](/chatbot/variables/customapi/):
+Because the output is a stable lowercase slug, it is most useful **nested inside other variables** — for example to build platform-aware responses with [`$(customapi)`](/chatbot/variables/customapi):
 
 ```streamelements
 $(customapi https://example.com/messages/$(provider))
@@ -53,14 +53,14 @@ $(customapi https://example.com/messages/$(provider))
 This requests a different URL per platform (`.../messages/twitch` on Twitch, `.../messages/kick` on Kick, and so on), so your API can return a platform-specific response.
 
 :::note
-[`$(if)`](/chatbot/variables/if/) cannot compare text, so `$(if $(provider) ...)` does not branch by platform — a slug like `twitch` always counts as false. Use the `$(customapi)` pattern above for platform-specific responses.
+[`$(if)`](/chatbot/variables/if) cannot compare text, so `$(if $(provider) ...)` does not branch by platform — a slug like `twitch` always counts as false. Use the `$(customapi)` pattern above for platform-specific responses.
 :::
 
 ## Related variables
 
-- [`$(channel)`](/chatbot/variables/channel/): `$(channel.provider)` returns the same value, alongside other channel fields.
-- [`$(customapi)`](/chatbot/variables/customapi/): Fetch a URL — combine with `$(provider)` for platform-aware responses.
-- [`$(if)`](/chatbot/variables/if/): Conditional output based on a true/false condition.
+- [`$(channel)`](/chatbot/variables/channel): `$(channel.provider)` returns the same value, alongside other channel fields.
+- [`$(customapi)`](/chatbot/variables/customapi): Fetch a URL — combine with `$(provider)` for platform-aware responses.
+- [`$(if)`](/chatbot/variables/if): Conditional output based on a true/false condition.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/pubg.mdx
+++ b/src/content/docs/chatbot/variables/pubg.mdx
@@ -94,8 +94,8 @@ Any other stat key returns an error (see below).
 
 ## Related variables
 
-- [`$(leagueoflegends)`](/chatbot/variables/leagueoflegends/): Get a League of Legends player's rank and LP.
-- [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics/): Get a Teamfight Tactics player's rank and LP.
+- [`$(leagueoflegends)`](/chatbot/variables/leagueoflegends): Get a League of Legends player's rank and LP.
+- [`$(teamfighttactics)`](/chatbot/variables/teamfighttactics): Get a Teamfight Tactics player's rank and LP.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/queryescape.mdx
+++ b/src/content/docs/chatbot/variables/queryescape.mdx
@@ -65,9 +65,9 @@ If no text is provided, the variable is not replaced and appears as literal text
 
 ## Related Variables
 
-- [`$(pathescape)`](/chatbot/variables/pathescape/): Escapes text for use in URL paths (encodes spaces as `%20`).
-- [`$(customapi)`](/chatbot/variables/customapi/): Used to fetch content from a URL, often combined with `$(queryescape)` for dynamic web requests.
-- [Argument tokens](/chatbot/variables/args/): Represent user input in custom commands, frequently used with `$(queryescape)` to create dynamic queries.
+- [`$(pathescape)`](/chatbot/variables/pathescape): Escapes text for use in URL paths (encodes spaces as `%20`).
+- [`$(customapi)`](/chatbot/variables/customapi): Used to fetch content from a URL, often combined with `$(queryescape)` for dynamic web requests.
+- [Argument tokens](/chatbot/variables/args): Represent user input in custom commands, frequently used with `$(queryescape)` to create dynamic queries.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/quote.mdx
+++ b/src/content/docs/chatbot/variables/quote.mdx
@@ -55,11 +55,11 @@ If the quote doesn't exist (or there are no quotes yet), the variable outputs `q
 
 - `id` (optional): The ID of the specific quote you want to display. If not provided, a random quote will be shown.
 
-The variable mirrors the lookup behavior of the [`!quote`](/chatbot/commands/default/quote/) command: no argument shows a random quote, and an ID shows that specific quote.
+The variable mirrors the lookup behavior of the [`!quote`](/chatbot/commands/default/quote) command: no argument shows a random quote, and an ID shows that specific quote.
 
 ## Related Commands
 
-- [`!quote`](/chatbot/commands/default/quote/): Add, remove, or display quotes in chat
+- [`!quote`](/chatbot/commands/default/quote): Add, remove, or display quotes in chat
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/random.mdx
+++ b/src/content/docs/chatbot/variables/random.mdx
@@ -134,8 +134,8 @@ The next game we'll play is: $(random.pick Fortnite,Minecraft,Valorant)
 
 ## Related Variables
 
-- [$(customapi)](/chatbot/variables/customapi/): Fetch content from a URL, which can be used to create more complex random selections
-- [$(math)](/chatbot/variables/math/): Perform mathematical operations and return the result
+- [$(customapi)](/chatbot/variables/customapi): Fetch content from a URL, which can be used to create more complex random selections
+- [$(math)](/chatbot/variables/math): Perform mathematical operations and return the result
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/redeem.mdx
+++ b/src/content/docs/chatbot/variables/redeem.mdx
@@ -68,8 +68,8 @@ The redemption follows the same rules as the loyalty store. Depending on the out
 
 ## Related variables
 
-- [`$(pointsname)`](/chatbot/variables/pointsname/): The channel's custom loyalty points name, used in the store replies.
-- [`$(user)`](/chatbot/variables/user/): `$(user.points)` shows a viewer's current points balance.
+- [`$(pointsname)`](/chatbot/variables/pointsname): The channel's custom loyalty points name, used in the store replies.
+- [`$(user)`](/chatbot/variables/user): `$(user.points)` shows a viewer's current points balance.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/repeat.mdx
+++ b/src/content/docs/chatbot/variables/repeat.mdx
@@ -67,8 +67,8 @@ If the count is missing, not a number, or less than 1, the bot sends nothing —
 
 ## Related Variables
 
-- [`$(queryescape)`](/chatbot/variables/queryescape/): Escapes text for use in URL query parameters.
-- [`$(random)`](/chatbot/variables/random/): Generates random numbers or selects random items, which can be used with `$(repeat)`.
+- [`$(queryescape)`](/chatbot/variables/queryescape): Escapes text for use in URL query parameters.
+- [`$(random)`](/chatbot/variables/random): Generates random numbers or selects random items, which can be used with `$(repeat)`.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/sender.mdx
+++ b/src/content/docs/chatbot/variables/sender.mdx
@@ -16,7 +16,7 @@ import ChatExample from '@components/ChatExample.astro';
 The `$(sender)` variable in StreamElements Chatbot always refers to the user who triggered the command or message. It provides access to various user-related information such as username, loyalty points, ranks, and activity timestamps.
 
 :::tip[Key Point]
-`$(sender)` always refers to the command trigger and doesn't accept arguments. If you need to query information about other users, use the [`$(user)`](/chatbot/variables/user/) variable instead.
+`$(sender)` always refers to the command trigger and doesn't accept arguments. If you need to query information about other users, use the [`$(user)`](/chatbot/variables/user) variable instead.
 :::
 
 ## Use it
@@ -44,7 +44,7 @@ To use the `$(sender)` variable, include it in your chat message or command resp
 | `$(sender.points)` | Sender's loyalty currency owned | |
 | `$(sender.points_rank)` | Sender's rank on the loyalty currency leaderboard | Returned as rank/total, e.g. `5/283`; `<error>` if the lookup fails |
 | `$(sender.points_alltime_rank)` | Sender's rank on the all-time loyalty currency leaderboard | Returned as rank/total, e.g. `5/283`; `<error>` if the lookup fails |
-| `$(sender.level)` | Sender's access level as a number | See [access levels](/chatbot/variables/user/#access-levels) |
+| `$(sender.level)` | Sender's access level as a number | See [access levels](/chatbot/variables/user#access-levels) |
 | `$(sender.lastmessage)` | Sender's last typed message in the chat | Outputs a single space if no message is stored |
 | `$(sender.lastseen)` | Time since the sender was most recently seen in the viewer list or chat | Returned as a duration, e.g. `13 mins 15 secs`; `<not found>` if never recorded |
 | `$(sender.lastactive)` | Time since the sender most recently typed a message in the chat | Returned as a duration, e.g. `13 mins 15 secs`; `<not found>` if never recorded |
@@ -86,7 +86,7 @@ Durations are written out in full words: `secs`, `mins`, `hours`, `days`, `month
 ## Best Practices
 
 1. Use `$(sender)` when you only need information about the command trigger.
-2. If you need to reference other users or allow flexible user queries, use the [`$(user)`](/chatbot/variables/user/) variable instead.
+2. If you need to reference other users or allow flexible user queries, use the [`$(user)`](/chatbot/variables/user) variable instead.
 
 ## Troubleshooting
 
@@ -95,7 +95,7 @@ Durations are written out in full words: `secs`, `mins`, `hours`, `days`, `month
 
 ## Related Variables
 
-- [`$(user)`](/chatbot/variables/user/): Query information about any user, not just the command sender.
+- [`$(user)`](/chatbot/variables/user): Query information about any user, not just the command sender.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/setgame.mdx
+++ b/src/content/docs/chatbot/variables/setgame.mdx
@@ -75,8 +75,8 @@ On success, the variable outputs the resolved category name (for example, settin
 
 ## Related Variables
 
-- [`$(settitle)`](/chatbot/variables/settitle/): Changes the stream title
-- [`$(game)`](/chatbot/variables/game/): Retrieves the current game or category
+- [`$(settitle)`](/chatbot/variables/settitle): Changes the stream title
+- [`$(game)`](/chatbot/variables/game): Retrieves the current game or category
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/settitle.mdx
+++ b/src/content/docs/chatbot/variables/settitle.mdx
@@ -68,8 +68,8 @@ On success, the variable outputs the new title. If the platform rejects the chan
 
 ## Related Variables
 
-- [`$(title)`](/chatbot/variables/title/): Retrieves the current stream title
-- [`$(game)`](/chatbot/variables/game/): Retrieves the current game or category of your stream
+- [`$(title)`](/chatbot/variables/title): Retrieves the current stream title
+- [`$(game)`](/chatbot/variables/game): Retrieves the current game or category of your stream
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/teamfighttactics.mdx
+++ b/src/content/docs/chatbot/variables/teamfighttactics.mdx
@@ -81,7 +81,7 @@ If the player is unranked, or the lookup fails for any reason, the output is `Un
 
 ## Related Variables
 
-- [`$(leagueoflegends)`](/chatbot/variables/leagueoflegends/): Look up a League of Legends player's rank
+- [`$(leagueoflegends)`](/chatbot/variables/leagueoflegends): Look up a League of Legends player's rank
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/title.mdx
+++ b/src/content/docs/chatbot/variables/title.mdx
@@ -69,9 +69,9 @@ This would return the title of the channel "OtherStreamer" instead of the curren
 
 ## Related Variables
 
-- [`$(game)`](/chatbot/variables/game/): Displays the current game or category of the stream
-- [`$(uptime)`](/chatbot/variables/uptime/): Shows how long the current stream has been live
-- [`$(settitle)`](/chatbot/variables/settitle/): Changes the stream title
+- [`$(game)`](/chatbot/variables/game): Displays the current game or category of the stream
+- [`$(uptime)`](/chatbot/variables/uptime): Shows how long the current stream has been live
+- [`$(settitle)`](/chatbot/variables/settitle): Changes the stream title
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/touser.mdx
+++ b/src/content/docs/chatbot/variables/touser.mdx
@@ -63,13 +63,13 @@ The `$(touser)` variable itself takes no parameters — it reads the first word 
 - **word**: The first word typed after the command. If provided, this word will be displayed instead of the command user's name.
 
 :::note
-`$(touser)` passes the word through without validating it as a username and without removing an `@` prefix. If you need validation or other-user lookups, use [argument tokens](/chatbot/variables/args/) like `$(1 username)` or the [`$(user)`](/chatbot/variables/user/) variable instead.
+`$(touser)` passes the word through without validating it as a username and without removing an `@` prefix. If you need validation or other-user lookups, use [argument tokens](/chatbot/variables/args) like `$(1 username)` or the [`$(user)`](/chatbot/variables/user) variable instead.
 :::
 
 ## Related Variables
 
-- [`$(sender)`](/chatbot/variables/sender/): Always displays the name of the user who triggered the command.
-- [Argument tokens](/chatbot/variables/args/) (`$(1)`, `$(1:)`): Access the words after the command directly, with optional fallbacks and validators.
+- [`$(sender)`](/chatbot/variables/sender): Always displays the name of the user who triggered the command.
+- [Argument tokens](/chatbot/variables/args) (`$(1)`, `$(1:)`): Access the words after the command directly, with optional fallbacks and validators.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/twitchemotes.mdx
+++ b/src/content/docs/chatbot/variables/twitchemotes.mdx
@@ -48,9 +48,9 @@ Let's celebrate with our awesome emotes! stylerXD stylerRIP stylerLOL stylerHYPE
 
 ## Related Variables
 
-- [$(bttvemotes)](/chatbot/variables/bttvemotes/): Lists active BetterTTV emotes in the channel
-- [$(ffzemotes)](/chatbot/variables/ffzemotes/): Lists active FrankerFaceZ emotes in the channel
-- [$(7tvemotes)](/chatbot/variables/7tvemotes/): Lists active 7TV emotes in the channel
+- [$(bttvemotes)](/chatbot/variables/bttvemotes): Lists active BetterTTV emotes in the channel
+- [$(ffzemotes)](/chatbot/variables/ffzemotes): Lists active FrankerFaceZ emotes in the channel
+- [$(7tvemotes)](/chatbot/variables/7tvemotes): Lists active 7TV emotes in the channel
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/uptime.mdx
+++ b/src/content/docs/chatbot/variables/uptime.mdx
@@ -56,8 +56,8 @@ shroud has been live for 3 hours 45 mins
 
 ## Related Variables
 
-- [`$(game)`](/chatbot/variables/game/): Displays the current game being played on the stream
-- [`$(title)`](/chatbot/variables/title/): Shows the current stream title
+- [`$(game)`](/chatbot/variables/game): Displays the current game being played on the stream
+- [`$(title)`](/chatbot/variables/title): Shows the current stream title
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/user.mdx
+++ b/src/content/docs/chatbot/variables/user.mdx
@@ -17,11 +17,11 @@ import ChatExample from '@components/ChatExample.astro';
 The `$(user)` variable in StreamElements Chatbot allows you to access and display various user-related information in your chat messages and commands. These variables provide data such as usernames, loyalty points, ranks, and activity timestamps.
 
 :::note
-`$(user)` and all of its sub-variables are not available on YouTube — there, the variable renders as literal text instead of being replaced. Use [`$(sender)`](/chatbot/variables/sender/) instead, which works on all platforms.
+`$(user)` and all of its sub-variables are not available on YouTube — there, the variable renders as literal text instead of being replaced. Use [`$(sender)`](/chatbot/variables/sender) instead, which works on all platforms.
 :::
 
 :::tip[Key Point]
-`$(user)` can accept an optional username argument to retrieve information about any user, not just the command sender. Without an explicit argument, it targets the first word typed after the command if that word looks like a username (a leading `@` is removed automatically); otherwise it falls back to the command sender, behaving similarly to [`$(sender)`](/chatbot/variables/sender/).
+`$(user)` can accept an optional username argument to retrieve information about any user, not just the command sender. Without an explicit argument, it targets the first word typed after the command if that word looks like a username (a leading `@` is removed automatically); otherwise it falls back to the command sender, behaving similarly to [`$(sender)`](/chatbot/variables/sender).
 :::
 
 ## Use it
@@ -110,8 +110,8 @@ Durations are written out in full words: `secs`, `mins`, `hours`, `days`, `month
 ## Troubleshooting
 
 - If a variable returns unexpected results, ensure you're using the correct syntax and that the user exists in your channel's database. Unknown users produce empty output.
-- Remember that `$(user)` variables can accept arguments. If you only need information about the command sender, consider using [`$(sender)`](/chatbot/variables/sender/) instead.
+- Remember that `$(user)` variables can accept arguments. If you only need information about the command sender, consider using [`$(sender)`](/chatbot/variables/sender) instead.
 
 ## Related Variables
 
-- [`$(sender)`](/chatbot/variables/sender/): Information specifically about the command sender.
+- [`$(sender)`](/chatbot/variables/sender): Information specifically about the command sender.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -8,14 +8,14 @@ hero:
   tagline: Everything you need to set up, customize, and build on StreamElements.
   actions:
     - text: Get started with the Chatbot
-      link: /chatbot/
+      link: /chatbot
       icon: right-arrow
     - text: Build a custom widget
-      link: /overlays/first-custom-widget/
+      link: /overlays/first-custom-widget
       icon: puzzle
       variant: secondary
     - text: What's new
-      link: /changelog/
+      link: /changelog
       icon: rocket
       variant: minimal
 ---
@@ -27,17 +27,17 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 <CardGrid>
   <LinkCard
     title="Chatbot"
-    href="/chatbot/"
+    href="/chatbot"
     description="Commands, variables, timers, spam filters, and interactive modules for your chat."
   />
   <LinkCard
     title="Overlays"
-    href="/overlays/"
+    href="/overlays"
     description="Build stream overlays — from your first AlertBox to fully custom-coded widgets."
   />
   <LinkCard
     title="WebSockets"
-    href="/websockets/"
+    href="/websockets"
     description="Subscribe to realtime events — tips, activities, chat, and overlay control — over the Astro protocol."
   />
   <LinkCard
@@ -47,7 +47,7 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
   />
   <LinkCard
     title="Changelog"
-    href="/changelog/"
+    href="/changelog"
     description="New updates and improvements at StreamElements, with RSS feeds per product."
   />
   <LinkCard

--- a/src/content/docs/overlays/custom-code-in-alertbox.md
+++ b/src/content/docs/overlays/custom-code-in-alertbox.md
@@ -13,11 +13,11 @@ keywords:
 
 ### Prerequisites
 
-This article requires you to have an Overlay created with an AlertBox with "Custom CSS" enabled. To do so, follow the steps in the [Getting Started](/overlays/getting-started/) article.
+This article requires you to have an Overlay created with an AlertBox with "Custom CSS" enabled. To do so, follow the steps in the [Getting Started](/overlays/getting-started) article.
 
 ## Custom Code Editor
 
-The Custom Code Editor is a powerful tool that allows you to write custom code in the Overlay Editor. For more information about the Custom Code Editor, please refer to the [Code Editor](/overlays/widget-structure/) article.
+The Custom Code Editor is a powerful tool that allows you to write custom code in the Overlay Editor. For more information about the Custom Code Editor, please refer to the [Code Editor](/overlays/widget-structure) article.
 
 ## Inline Variables available
 

--- a/src/content/docs/overlays/custom-widget.md
+++ b/src/content/docs/overlays/custom-widget.md
@@ -20,11 +20,11 @@ You cannot access `document.cookie` nor `IndexedDB` (security reasons), so you n
 
 ### Prerequisites
 
-This article requires you to have an Overlay created with a Custom Widget added there. To do so, follow the steps in the [Getting Started](/overlays/getting-started/) article.
+This article requires you to have an Overlay created with a Custom Widget added there. To do so, follow the steps in the [Getting Started](/overlays/getting-started) article.
 
 ### Custom Code Editor
 
-The Custom Code Editor is a powerful tool that allows you to write custom code in the Overlay Editor. For more information about the Custom Code Editor, please refer to the [Code Editor](/overlays/widget-structure/) article.
+The Custom Code Editor is a powerful tool that allows you to write custom code in the Overlay Editor. For more information about the Custom Code Editor, please refer to the [Code Editor](/overlays/widget-structure) article.
 
 ## SE_API
 
@@ -236,7 +236,7 @@ See [Queue management with widgetDuration](#queue-management-with-widgetduration
 
 ## Queue management with widgetDuration
 
-The `widgetDuration` property defines the maximum event queue hold time (execution time of widget) by widget in seconds (default is 0). For example, if you want to show animations by this widget and don't want them to overlap, instead of building your own queue, you can use this. This property is defined in the widget's fields JSON (see [Custom Fields](/overlays/widget-structure/#custom-fields)). Premature queue resume can be called by `SE_API.resumeQueue();`.
+The `widgetDuration` property defines the maximum event queue hold time (execution time of widget) by widget in seconds (default is 0). For example, if you want to show animations by this widget and don't want them to overlap, instead of building your own queue, you can use this. This property is defined in the widget's fields JSON (see [Custom Fields](/overlays/widget-structure#custom-fields)). Premature queue resume can be called by `SE_API.resumeQueue();`.
 
 The best way to explain this is through an example.
 

--- a/src/content/docs/overlays/events.mdx
+++ b/src/content/docs/overlays/events.mdx
@@ -56,12 +56,12 @@ window.addEventListener('onWidgetLoad', function (obj) {
 <LinkCard
   title="Session Data Reference"
   description="All session object keys: tips, followers, subscribers, cheers, Super Chats, and more."
-  href="/overlays/session-data/"
+  href="/overlays/session-data"
 />
 
 ### Recents and currency
 
-There is also a list in chronological order of last 25 events (so if you want to make a list of all events - use this one) - variable `recents` initialized one line after variable `data`. It is an array of elements (each of them is an array) with the same elements as in `data["*-recent"]` (see [Recent events](/overlays/session-data/#recent-events)).
+There is also a list in chronological order of last 25 events (so if you want to make a list of all events - use this one) - variable `recents` initialized one line after variable `data`. It is an array of elements (each of them is an array) with the same elements as in `data["*-recent"]` (see [Recent events](/overlays/session-data#recent-events)).
 
 The last element of `obj` is `currency`, which contains:
 
@@ -100,7 +100,7 @@ In the example above you have `obj` forwarded to that function, which has two in
 | `event:skip` | User clicked "skip alert" button in activity feed |
 | `alertService:toggleSound` | User clicked "mute/unmute alerts" button in activity feed |
 | `bot:counter` | Update of [bot counter](#bot-counter) |
-| `kvstore:update` | Update of [SE_API](/overlays/custom-widget/#se_api) store value |
+| `kvstore:update` | Update of [SE_API](/overlays/custom-widget#se_api) store value |
 | `widget-button` | User clicked [custom field button](#button-click) in widget properties |
 
 ### Event details
@@ -340,4 +340,4 @@ window.addEventListener('onSessionUpdate', function (obj) {
 });
 ```
 
-`data` is the same as in `onWidgetLoad`, so every property is listed in the [Session Data Reference](/overlays/session-data/).
+`data` is the same as in `onWidgetLoad`, so every property is listed in the [Session Data Reference](/overlays/session-data).

--- a/src/content/docs/overlays/first-custom-widget.mdx
+++ b/src/content/docs/overlays/first-custom-widget.mdx
@@ -17,7 +17,7 @@ In this tutorial you'll build a small widget that shows a configurable text labe
 
 1. **Create an overlay and add a Custom Widget**
 
-   Follow [Getting Started](/overlays/getting-started/) to create an overlay, then add a **Custom Widget** from the **STATIC/CUSTOM** section of the widget picker.
+   Follow [Getting Started](/overlays/getting-started) to create an overlay, then add a **Custom Widget** from the **STATIC/CUSTOM** section of the widget picker.
 
 2. **Open the Custom Code Editor**
 
@@ -28,7 +28,7 @@ In this tutorial you'll build a small widget that shows a configurable text labe
    - **JS** — pure JavaScript or external libraries; code runs in a protected sandbox.
    - **FIELDS** — JSON definitions of configurable variables, displayed in the left panel so the end user doesn't have to interact with code.
 
-   See [Code Editor](/overlays/widget-structure/) for the full reference.
+   See [Code Editor](/overlays/widget-structure) for the full reference.
 
 3. **Define the fields**
 
@@ -49,7 +49,7 @@ In this tutorial you'll build a small widget that shows a configurable text labe
    }
    ```
 
-   These two inputs now appear in the left panel of the Overlay Editor. The [Code Editor](/overlays/widget-structure/#custom-fields) page lists all supported field types, such as `dropdown`, `slider`, `image-input`, and `googleFont`.
+   These two inputs now appear in the left panel of the Overlay Editor. The [Code Editor](/overlays/widget-structure#custom-fields) page lists all supported field types, such as `dropdown`, `slider`, `image-input`, and `googleFont`.
 
 4. **Write the HTML**
 
@@ -91,7 +91,7 @@ In this tutorial you'll build a small widget that shows a configurable text labe
    ```
 
    :::tip[Explore the event object]
-   The session data structure may change over time. To inspect the most up-to-date values, use `console.log(obj)` and check your browser console. The available keys (followers, subscribers, tips, cheers, and more) are listed in the [Session Data Reference](/overlays/session-data/).
+   The session data structure may change over time. To inspect the most up-to-date values, use `console.log(obj)` and check your browser console. The available keys (followers, subscribers, tips, cheers, and more) are listed in the [Session Data Reference](/overlays/session-data).
    :::
 
 7. **React to new followers**
@@ -122,7 +122,7 @@ In this tutorial you'll build a small widget that shows a configurable text labe
 
 8. **Try it out**
 
-   Change the **Some Text** field and the color picker in the left panel and watch the widget update. The full list of listener values and event payloads is in [Widget Events](/overlays/events/).
+   Change the **Some Text** field and the color picker in the left panel and watch the widget update. The full list of listener values and event payloads is in [Widget Events](/overlays/events).
 
 </Steps>
 
@@ -131,17 +131,17 @@ In this tutorial you'll build a small widget that shows a configurable text labe
 <CardGrid>
   <LinkCard
     title="SE_API Reference"
-    href="/overlays/custom-widget/"
+    href="/overlays/custom-widget"
     description="Persist data with the key-value store, read bot counters, and control the event queue."
   />
   <LinkCard
     title="Widget Events"
-    href="/overlays/events/"
+    href="/overlays/events"
     description="Full reference for onWidgetLoad, onEventReceived, and onSessionUpdate payloads."
   />
   <LinkCard
     title="Session Data Reference"
-    href="/overlays/session-data/"
+    href="/overlays/session-data"
     description="Every session data key available to your widget, for Twitch and YouTube."
   />
 </CardGrid>

--- a/src/content/docs/overlays/getting-started.mdx
+++ b/src/content/docs/overlays/getting-started.mdx
@@ -95,17 +95,17 @@ To create a Custom Widget:
 <CardGrid>
   <LinkCard
     title="Your First Custom Widget"
-    href="/overlays/first-custom-widget/"
+    href="/overlays/first-custom-widget"
     description="Step-by-step tutorial: define fields, write HTML/CSS/JS, and react to a follow event."
   />
   <LinkCard
     title="Code Editor"
-    href="/overlays/widget-structure/"
+    href="/overlays/widget-structure"
     description="Write HTML, CSS, JavaScript, and custom field definitions in the Custom Code Editor."
   />
   <LinkCard
     title="Custom Code in Alertboxes"
-    href="/overlays/custom-code-in-alertbox/"
+    href="/overlays/custom-code-in-alertbox"
     description="Build fully custom alert designs with inline template variables for names, amounts, and messages."
   />
 </CardGrid>

--- a/src/content/docs/overlays/index.mdx
+++ b/src/content/docs/overlays/index.mdx
@@ -22,17 +22,17 @@ Set up overlays, alerts, and widgets in the Overlay Editor — no coding require
 <CardGrid>
   <LinkCard
     title="Getting Started"
-    href="/overlays/getting-started/"
+    href="/overlays/getting-started"
     description="Create your first overlay and add an AlertBox or Custom Widget in the Overlay Editor."
   />
   <LinkCard
     title="Custom Code in Alertboxes"
-    href="/overlays/custom-code-in-alertbox/"
+    href="/overlays/custom-code-in-alertbox"
     description="Build fully custom alert designs with inline template variables for names, amounts, and messages."
   />
   <LinkCard
     title="Editor Shortcuts"
-    href="/overlays/overlay-editor-shortcuts/"
+    href="/overlays/overlay-editor-shortcuts"
     description="Keyboard shortcuts for moving, duplicating, and grouping widgets in the Overlay Editor."
   />
 </CardGrid>
@@ -44,27 +44,27 @@ Build your own widgets with HTML, CSS, and JavaScript, react to stream events, a
 <CardGrid>
   <LinkCard
     title="Your First Custom Widget"
-    href="/overlays/first-custom-widget/"
+    href="/overlays/first-custom-widget"
     description="Step-by-step tutorial: define fields, write HTML/CSS/JS, and react to a follow event."
   />
   <LinkCard
     title="Code Editor"
-    href="/overlays/widget-structure/"
+    href="/overlays/widget-structure"
     description="Write HTML, CSS, JavaScript, and custom field definitions in the Custom Code Editor."
   />
   <LinkCard
     title="SE_API Reference"
-    href="/overlays/custom-widget/"
+    href="/overlays/custom-widget"
     description="Use the SE_API store, counters, queue control, and more from your custom widgets."
   />
   <LinkCard
     title="Widget Events"
-    href="/overlays/events/"
+    href="/overlays/events"
     description="Handle onWidgetLoad, onEventReceived, and onSessionUpdate events in your widget code."
   />
   <LinkCard
     title="Session Data Reference"
-    href="/overlays/session-data/"
+    href="/overlays/session-data"
     description="Session data keys for followers, subscribers, tips, cheers, and more, available to widget code."
   />
 </CardGrid>

--- a/src/content/docs/overlays/session-data.md
+++ b/src/content/docs/overlays/session-data.md
@@ -9,7 +9,7 @@ keywords:
   - Stream overlay development
 ---
 
-The session `data` object holds per-feature totals, goals, and latest-event details for your channel — the same values visible in the [Session Dashboard](https://streamelements.com/dashboard/session). Custom widgets receive it through the [onWidgetLoad and onSessionUpdate events](/overlays/events/):
+The session `data` object holds per-feature totals, goals, and latest-event details for your channel — the same values visible in the [Session Dashboard](https://streamelements.com/dashboard/session). Custom widgets receive it through the [onWidgetLoad and onSessionUpdate events](/overlays/events):
 
 - In `onWidgetLoad`, `data` is available at `obj.detail.session.data`
 - In `onSessionUpdate`, `data` is available at `obj.detail.session`

--- a/src/content/docs/overlays/widget-structure.md
+++ b/src/content/docs/overlays/widget-structure.md
@@ -65,7 +65,7 @@ Adding an invalid type will default it to `"type":"text"`.
 | `video-input` | Library input for selecting a video. | `"multiple": true` (as above) |
 | `sound-input` | Library input for selecting audio. | `"multiple": true` (as above) |
 | `googleFont` | Google Font picker; `value` is a font name such as `"Roboto"`. | — |
-| `button` | Button in the left panel; clicking it emits a [`widget-button` event](/overlays/events/#button-click). | — |
+| `button` | Button in the left panel; clicking it emits a [`widget-button` event](/overlays/events#button-click). | — |
 | `hidden` | Not displayed in the left panel; used for reserved fields such as `widgetName` and `widgetDuration`. | — |
 
 If you want to group some fields into a collapsible menu in the left panel, you can add to them the same parameter `"group": "Some group name"`.
@@ -78,7 +78,7 @@ There are some reserved field names (all future reserved words will start with `
 |-------|--------|
 | `widgetName` | Used to set the display name of the widget. |
 | `widgetAuthor` | Sets the author name of the widget (adds a "(by Author)" to the widget name). |
-| `widgetDuration` | Maximum event queue hold time (seconds) - for Custom Widget (as alertboxes have their own timers). Explained in [Queue management with widgetDuration](/overlays/custom-widget/#queue-management-with-widgetduration). |
+| `widgetDuration` | Maximum event queue hold time (seconds) - for Custom Widget (as alertboxes have their own timers). Explained in [Queue management with widgetDuration](/overlays/custom-widget#queue-management-with-widgetduration). |
 
 ### Example
 

--- a/src/content/docs/websockets/examples.mdx
+++ b/src/content/docs/websockets/examples.mdx
@@ -675,7 +675,7 @@ const subscribeMessage = {
 
 ### How do I handle rate limiting?
 
-If you receive a `rate_limit_exceeded` error, back off before retrying. See [Rate Limits](/websockets/#rate-limits) for the current limits:
+If you receive a `rate_limit_exceeded` error, back off before retrying. See [Rate Limits](/websockets#rate-limits) for the current limits:
 
 ```javascript
 websocket.addEventListener('message', (event) => {
@@ -697,11 +697,11 @@ websocket.addEventListener('message', (event) => {
   <LinkCard
     title="WebSockets"
     description="Full protocol reference for the Astro websocket gateway."
-    href="/websockets/"
+    href="/websockets"
   />
   <LinkCard
     title="Topics"
     description="All available topics and their payload schemas."
-    href="/websockets/topics/"
+    href="/websockets/topics"
   />
 </CardGrid>

--- a/src/content/docs/websockets/index.mdx
+++ b/src/content/docs/websockets/index.mdx
@@ -17,12 +17,12 @@ Astro is StreamElements' dedicated websocket gateway. It employs a publish-subsc
   <LinkCard
     title="Client Examples"
     description="Working client implementations in JavaScript, Node.js, Python, C#, and Go."
-    href="/websockets/examples/"
+    href="/websockets/examples"
   />
   <LinkCard
     title="Topics"
     description="All available topics and their payload schemas."
-    href="/websockets/topics/"
+    href="/websockets/topics"
   />
 </CardGrid>
 
@@ -228,7 +228,7 @@ When a message is published to a topic the client is subscribed to:
 }
 ```
 
-The `data` field contains the payload from the publisher. See individual [topic pages](/websockets/topics/) for payload details.
+The `data` field contains the payload from the publisher. See individual [topic pages](/websockets/topics) for payload details.
 
 ## Error Codes
 

--- a/src/content/docs/websockets/topics/channel-activities.md
+++ b/src/content/docs/websockets/topics/channel-activities.md
@@ -95,6 +95,6 @@ The possible activity `type`s are:
 
 ## Related
 
-- [Tips](/websockets/topics/channel-tips/) - Tip/donation events
-- [Session Update](/websockets/topics/channel-session-update/) - Individual session data updates
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Tips](/websockets/topics/channel-tips) - Tip/donation events
+- [Session Update](/websockets/topics/channel-session-update) - Individual session data updates
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/channel-chat-message.mdx
+++ b/src/content/docs/websockets/topics/channel-chat-message.mdx
@@ -205,5 +205,5 @@ Payloads are delivered in the raw format of the originating provider, so the str
 
 ## Related
 
-- [Activities](/websockets/topics/channel-activities/) - General channel activity events
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Activities](/websockets/topics/channel-activities) - General channel activity events
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/channel-contests.md
+++ b/src/content/docs/websockets/topics/channel-contests.md
@@ -154,5 +154,5 @@ stateDiagram-v2
 
 ## Related
 
-- [Activities](/websockets/topics/channel-activities/) - General channel activity events
-- [Websockets](/websockets/) - General information about the Astro WebSocket Gateway
+- [Activities](/websockets/topics/channel-activities) - General channel activity events
+- [Websockets](/websockets) - General information about the Astro WebSocket Gateway

--- a/src/content/docs/websockets/topics/channel-giveaway.md
+++ b/src/content/docs/websockets/topics/channel-giveaway.md
@@ -226,6 +226,6 @@ Single entry refunded.
 
 ## Related
 
-- [Contests](/websockets/topics/channel-contests/) - Contest and prediction events
-- [Activities](/websockets/topics/channel-activities/) - General channel activity events
-- [Websockets](/websockets/) - General information about the Astro WebSocket Gateway
+- [Contests](/websockets/topics/channel-contests) - Contest and prediction events
+- [Activities](/websockets/topics/channel-activities) - General channel activity events
+- [Websockets](/websockets) - General information about the Astro WebSocket Gateway

--- a/src/content/docs/websockets/topics/channel-overlay-action.md
+++ b/src/content/docs/websockets/topics/channel-overlay-action.md
@@ -49,6 +49,6 @@ The `channel.overlay.action` topic provides real-time updates when actions are p
 
 ## Related
 
-- [Overlay Broadcast](/websockets/topics/channel-overlay-broadcast/) - Custom broadcast events targeting overlays
-- [Overlay Update](/websockets/topics/channel-overlay-update/) - Overlay update notifications
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Overlay Broadcast](/websockets/topics/channel-overlay-broadcast) - Custom broadcast events targeting overlays
+- [Overlay Update](/websockets/topics/channel-overlay-update) - Overlay update notifications
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/channel-overlay-broadcast.md
+++ b/src/content/docs/websockets/topics/channel-overlay-broadcast.md
@@ -42,7 +42,7 @@ The `channel.overlay.broadcast` topic delivers custom events to a channel's over
 
 ## Example: KappaGen
 
-StreamElements itself uses this topic: when a viewer uses the chatbot's [`!kappagen`](/chatbot/commands/default/kappagen/) command, the chatbot broadcasts an `emotesplosion-kappagen` event to all of the channel's overlays, with the chat message that triggered the command as the event payload.
+StreamElements itself uses this topic: when a viewer uses the chatbot's [`!kappagen`](/chatbot/commands/default/kappagen) command, the chatbot broadcasts an `emotesplosion-kappagen` event to all of the channel's overlays, with the chat message that triggered the command as the event payload.
 
 ```json
 {
@@ -63,6 +63,6 @@ StreamElements itself uses this topic: when a viewer uses the chatbot's [`!kappa
 
 ## Related
 
-- [Overlay Action](/websockets/topics/channel-overlay-action/) - Overlay action events
-- [Overlay Update](/websockets/topics/channel-overlay-update/) - Overlay update notifications
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Overlay Action](/websockets/topics/channel-overlay-action) - Overlay action events
+- [Overlay Update](/websockets/topics/channel-overlay-update) - Overlay update notifications
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/channel-overlay-update.md
+++ b/src/content/docs/websockets/topics/channel-overlay-update.md
@@ -135,6 +135,6 @@ This event is triggered when an overlay's configuration is modified, such as whe
 
 ## Related
 
-- [Overlay Action](/websockets/topics/channel-overlay-action/) - Overlay action events
-- [Overlay Broadcast](/websockets/topics/channel-overlay-broadcast/) - Custom broadcast events targeting overlays
-- [Websockets](/websockets/) - General information about the Astro WebSocket Gateway
+- [Overlay Action](/websockets/topics/channel-overlay-action) - Overlay action events
+- [Overlay Broadcast](/websockets/topics/channel-overlay-broadcast) - Custom broadcast events targeting overlays
+- [Websockets](/websockets) - General information about the Astro WebSocket Gateway

--- a/src/content/docs/websockets/topics/channel-session-reset.md
+++ b/src/content/docs/websockets/topics/channel-session-reset.md
@@ -38,6 +38,6 @@ This event is triggered when your channel session is completely reset. It delive
 
 ## Related
 
-- [Session Update](/websockets/topics/channel-session-update/) - Individual session data updates
-- [Activities](/websockets/topics/channel-activities/) - Channel activity notifications
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Session Update](/websockets/topics/channel-session-update) - Individual session data updates
+- [Activities](/websockets/topics/channel-activities) - Channel activity notifications
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/channel-session-update.md
+++ b/src/content/docs/websockets/topics/channel-session-update.md
@@ -54,6 +54,6 @@ This event is triggered when specific elements of your channel session are modif
 
 ## Related
 
-- [Session Reset](/websockets/topics/channel-session-reset/) - Full session reset notifications
-- [Activities](/websockets/topics/channel-activities/) - Channel activity notifications
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Session Reset](/websockets/topics/channel-session-reset) - Full session reset notifications
+- [Activities](/websockets/topics/channel-activities) - Channel activity notifications
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/channel-songrequest.md
+++ b/src/content/docs/websockets/topics/channel-songrequest.md
@@ -396,6 +396,6 @@ The payload contains the full `SongrequestSettings` object.
 
 ## Related
 
-- [Overlay Action](/websockets/topics/channel-overlay-action/) - Overlay action events
-- [Activities](/websockets/topics/channel-activities/) - General channel activity events
-- [Websockets](/websockets/) - General information about the Astro WebSocket Gateway
+- [Overlay Action](/websockets/topics/channel-overlay-action) - Overlay action events
+- [Activities](/websockets/topics/channel-activities) - General channel activity events
+- [Websockets](/websockets) - General information about the Astro WebSocket Gateway

--- a/src/content/docs/websockets/topics/channel-stream-status.md
+++ b/src/content/docs/websockets/topics/channel-stream-status.md
@@ -34,5 +34,5 @@ The `channel.stream.status` topic provides real-time updates about whether a cha
 
 ## Related
 
-- [Session Update](/websockets/topics/channel-session-update/) - Individual session data updates
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Session Update](/websockets/topics/channel-session-update) - Individual session data updates
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/channel-tips-moderation.md
+++ b/src/content/docs/websockets/topics/channel-tips-moderation.md
@@ -114,5 +114,5 @@ A rejected tip matches the allowed payload, with `approved` set to `"rejected"`.
 
 ## Related
 
-- [Tips](/websockets/topics/channel-tips/) - Tip/donation events
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Tips](/websockets/topics/channel-tips) - Tip/donation events
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/channel-tips.md
+++ b/src/content/docs/websockets/topics/channel-tips.md
@@ -26,7 +26,7 @@ The `channel.tips` topic provides real-time updates about the tips/donations on 
 | `data._id` | `string` | Unique tip identifier |
 | `data.channel` | `string` | Channel ID |
 | `data.provider` | `string` | Payment provider (e.g., `paypal`) |
-| `data.approved` | `string` | Moderation state of the tip (see [Tips Moderation](/websockets/topics/channel-tips-moderation/)) |
+| `data.approved` | `string` | Moderation state of the tip (see [Tips Moderation](/websockets/topics/channel-tips-moderation)) |
 | `data.status` | `string` | Transaction status |
 | `data.createdAt` | `string` | Timestamp of tip creation |
 | `data.updatedAt` | `string` | Timestamp of last status update |
@@ -68,6 +68,6 @@ The `channel.tips` topic provides real-time updates about the tips/donations on 
 
 ## Related
 
-- [Tips Moderation](/websockets/topics/channel-tips-moderation/) - Tip moderation status updates
-- [Activities](/websockets/topics/channel-activities/) - General channel activity events
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Tips Moderation](/websockets/topics/channel-tips-moderation) - Tip moderation status updates
+- [Activities](/websockets/topics/channel-activities) - General channel activity events
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/chatbot-counters.md
+++ b/src/content/docs/websockets/topics/chatbot-counters.md
@@ -10,7 +10,7 @@ keywords:
 - bot counter
 ---
 
-This event is triggered whenever a chatbot counter value changes, whether through increment, decrement, or reset operations. Counter changes can originate from counter edits in the dashboard, the [`$(count)`](/chatbot/variables/count/) variable, or the [`!editcounter`](/chatbot/commands/default/editcounter/) command. It provides real-time updates of counter values, enabling immediate synchronization across your applications. Subscribe to this topic to receive real-time notifications about changes to your chatbot counters. This is particularly useful for maintaining accurate counter displays in overlays, applications, or other integrations that need to reflect the current state of your chatbot counters.
+This event is triggered whenever a chatbot counter value changes, whether through increment, decrement, or reset operations. Counter changes can originate from counter edits in the dashboard, the [`$(count)`](/chatbot/variables/count) variable, or the [`!editcounter`](/chatbot/commands/default/editcounter) command. It provides real-time updates of counter values, enabling immediate synchronization across your applications. Subscribe to this topic to receive real-time notifications about changes to your chatbot counters. This is particularly useful for maintaining accurate counter displays in overlays, applications, or other integrations that need to reflect the current state of your chatbot counters.
 
 :::note
 Deleting a counter and resetting a counter both publish an event with a `value` of `0` — subscribers cannot distinguish a deletion from a reset.
@@ -55,6 +55,6 @@ Deleting a counter and resetting a counter both publish an event with a `value` 
 
 ## Related
 
-- [Chatbot Status](/websockets/topics/chatbot-status/) - Chatbot connection status
-- [Chatbot Timeout](/websockets/topics/chatbot-timeout/) - User timeout notifications
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Chatbot Status](/websockets/topics/chatbot-status) - Chatbot connection status
+- [Chatbot Timeout](/websockets/topics/chatbot-timeout) - User timeout notifications
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/chatbot-modules-emotecombo.md
+++ b/src/content/docs/websockets/topics/chatbot-modules-emotecombo.md
@@ -41,5 +41,5 @@ The event only fires when the combo count has reached the configured minimum (3 
 
 ## Related
 
-- [Pyramid Module](/websockets/topics/chatbot-modules-pyramid/) - Chat pyramid detection events
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Pyramid Module](/websockets/topics/chatbot-modules-pyramid) - Chat pyramid detection events
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/chatbot-modules-pyramid.md
+++ b/src/content/docs/websockets/topics/chatbot-modules-pyramid.md
@@ -41,5 +41,5 @@ The event only fires for pyramids that reach a peak width of at least 3.
 
 ## Related
 
-- [Emote Combo Module](/websockets/topics/chatbot-modules-emotecombo/) - Emote combo trigger events
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Emote Combo Module](/websockets/topics/chatbot-modules-emotecombo) - Emote combo trigger events
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/chatbot-status.md
+++ b/src/content/docs/websockets/topics/chatbot-status.md
@@ -39,6 +39,6 @@ Each event contains exactly one of the following fields:
 
 ## Related
 
-- [Chatbot Counters](/websockets/topics/chatbot-counters/) - Chatbot counter value changes
-- [Chatbot Timeout](/websockets/topics/chatbot-timeout/) - User timeout notifications
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Chatbot Counters](/websockets/topics/chatbot-counters) - Chatbot counter value changes
+- [Chatbot Timeout](/websockets/topics/chatbot-timeout) - User timeout notifications
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/chatbot-timeout.md
+++ b/src/content/docs/websockets/topics/chatbot-timeout.md
@@ -13,5 +13,5 @@ Once released, this event will be triggered when the chatbot times out a user in
 
 ## Related
 
-- [Chatbot Status](/websockets/topics/chatbot-status/) - Chatbot connection status changes
-- [Websockets](/websockets/) - General information about the Astro Websocket Gateway
+- [Chatbot Status](/websockets/topics/chatbot-status) - Chatbot connection status changes
+- [Websockets](/websockets) - General information about the Astro Websocket Gateway

--- a/src/content/docs/websockets/topics/index.mdx
+++ b/src/content/docs/websockets/topics/index.mdx
@@ -28,23 +28,23 @@ Unlinked topics are valid for subscription but are not yet documented. Topics ma
 
 | Topic | Required Scope | Description |
 | --- | --- | --- |
-| [channel.session.update](/websockets/topics/channel-session-update/) | `session:read` | Individual session data updates |
-| [channel.session.reset](/websockets/topics/channel-session-reset/) | `session:read` | Full session reset events |
-| [channel.stream.status](/websockets/topics/channel-stream-status/) | `stream-live:read` | Stream online/offline status changes |
+| [channel.session.update](/websockets/topics/channel-session-update) | `session:read` | Individual session data updates |
+| [channel.session.reset](/websockets/topics/channel-session-reset) | `session:read` | Full session reset events |
+| [channel.stream.status](/websockets/topics/channel-stream-status) | `stream-live:read` | Stream online/offline status changes |
 
 ## Activity & Engagement
 
 | Topic | Required Scope | Description |
 | --- | --- | --- |
-| [channel.activities](/websockets/topics/channel-activities/) | `activities:read` | Channel activities like follows, subscriptions, and donations |
+| [channel.activities](/websockets/topics/channel-activities) | `activities:read` | Channel activities like follows, subscriptions, and donations |
 | `channel.announcements` | `channel:read` | Channel announcement events |
 | `channel.chatstats` | *(none)* | Chat statistics updates |
-| [channel.chat.message](/websockets/topics/channel-chat-message/) | `overlays:read` | Individual chat messages |
-| [channel.tips](/websockets/topics/channel-tips/) | `tips:read` | Tip/donation events |
-| [channel.tips.moderation](/websockets/topics/channel-tips-moderation/) | `tips:moderation` | Tip moderation events |
-| [channel.contests](/websockets/topics/channel-contests/) | *(none)* | Contest and prediction events |
-| [channel.giveaways](/websockets/topics/channel-giveaway/) | *(none)* | Giveaway events |
-| [channel.songrequest](/websockets/topics/channel-songrequest/) | `overlays:read` | Song request events |
+| [channel.chat.message](/websockets/topics/channel-chat-message) | `overlays:read` | Individual chat messages |
+| [channel.tips](/websockets/topics/channel-tips) | `tips:read` | Tip/donation events |
+| [channel.tips.moderation](/websockets/topics/channel-tips-moderation) | `tips:moderation` | Tip moderation events |
+| [channel.contests](/websockets/topics/channel-contests) | *(none)* | Contest and prediction events |
+| [channel.giveaways](/websockets/topics/channel-giveaway) | *(none)* | Giveaway events |
+| [channel.songrequest](/websockets/topics/channel-songrequest) | `overlays:read` | Song request events |
 | `channel.loyalty.redemptions` | `store:read` | Loyalty store redemption events |
 | `channel.loyalty.items` | `store:read` | Loyalty store item updates |
 
@@ -52,21 +52,21 @@ Unlinked topics are valid for subscription but are not yet documented. Topics ma
 
 | Topic | Required Scope | Description |
 | --- | --- | --- |
-| [channel.overlay.action](/websockets/topics/channel-overlay-action/) | `overlays:read` | Overlay action events (pause, mute, skip, etc.) |
-| [channel.overlay.broadcast](/websockets/topics/channel-overlay-broadcast/) | `overlays:broadcast` | Custom broadcast events targeting overlays |
-| [channel.overlay.update](/websockets/topics/channel-overlay-update/) | `overlays:read` | Overlay update notifications |
+| [channel.overlay.action](/websockets/topics/channel-overlay-action) | `overlays:read` | Overlay action events (pause, mute, skip, etc.) |
+| [channel.overlay.broadcast](/websockets/topics/channel-overlay-broadcast) | `overlays:broadcast` | Custom broadcast events targeting overlays |
+| [channel.overlay.update](/websockets/topics/channel-overlay-update) | `overlays:read` | Overlay update notifications |
 | `channel.kvstore.update` | `kvstore:read` | Key-value store update events |
 
 ## Chatbot
 
 | Topic | Required Scope | Description |
 | --- | --- | --- |
-| [channel.chatbot.status](/websockets/topics/chatbot-status/) | `bot:read` | Chatbot connection status changes |
-| [channel.chatbot.modules.pyramid](/websockets/topics/chatbot-modules-pyramid/) | `bot:read` | Chat pyramid detection events |
-| [channel.chatbot.modules.emotecombo](/websockets/topics/chatbot-modules-emotecombo/) | `bot:read` | Emote combo trigger events |
+| [channel.chatbot.status](/websockets/topics/chatbot-status) | `bot:read` | Chatbot connection status changes |
+| [channel.chatbot.modules.pyramid](/websockets/topics/chatbot-modules-pyramid) | `bot:read` | Chat pyramid detection events |
+| [channel.chatbot.modules.emotecombo](/websockets/topics/chatbot-modules-emotecombo) | `bot:read` | Emote combo trigger events |
 | `channel.chatbot.modules` | `bot:read` | General chatbot module updates <Badge text="Not published" variant="caution" /> |
 | `channel.chatbot.commands` | `bot:read` | Chatbot command updates <Badge text="Not published" variant="caution" /> |
 | `channel.chatbot.timers` | `bot:read` | Chatbot timer updates <Badge text="Not published" variant="caution" /> |
-| [channel.chatbot.counters](/websockets/topics/chatbot-counters/) | *(none)* | Chatbot counter value changes |
+| [channel.chatbot.counters](/websockets/topics/chatbot-counters) | *(none)* | Chatbot counter value changes |
 | `channel.chatbot.filters` | `bot:read` | Chatbot filter updates <Badge text="Not published" variant="caution" /> |
-| [channel.chatbot.timeout](/websockets/topics/chatbot-timeout/) | — | User timeout notifications <Badge text="In development" variant="caution" /> |
+| [channel.chatbot.timeout](/websockets/topics/chatbot-timeout) | — | User timeout notifications <Badge text="In development" variant="caution" /> |

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -6,9 +6,9 @@ import { getCollection, type CollectionEntry } from 'astro:content';
  * filtered feeds (/changelog/product/{id}/).
  */
 export const PRODUCTS = {
-  chatbot: { name: 'Chatbot', url: '/chatbot/' },
-  overlays: { name: 'Overlays', url: '/overlays/' },
-  websockets: { name: 'WebSockets', url: '/websockets/' },
+  chatbot: { name: 'Chatbot', url: '/chatbot' },
+  overlays: { name: 'Overlays', url: '/overlays' },
+  websockets: { name: 'WebSockets', url: '/websockets' },
   dashboard: { name: 'Dashboard', url: 'https://streamelements.com/dashboard' },
   docs: { name: 'Docs', url: '/' },
 } as const;
@@ -47,7 +47,7 @@ export async function getChangelog(): Promise<ChangelogEntry[]> {
       const slug = rest.join('/');
       const conflict = seen.get(slug);
       if (conflict) {
-        throw new Error(`Changelog slug collision: "${entry.id}" and "${conflict}" both map to /changelog/post/${slug}/`);
+        throw new Error(`Changelog slug collision: "${entry.id}" and "${conflict}" both map to /changelog/post/${slug}`);
       }
       seen.set(slug, entry.id);
       return { ...entry, slug, data: { ...entry.data, products } };

--- a/src/pages/changelog/[...page].astro
+++ b/src/pages/changelog/[...page].astro
@@ -11,4 +11,4 @@ export const getStaticPaths = (async ({ paginate }) => {
 const { page } = Astro.props;
 ---
 
-<ChangelogFeedPage page={page} baseUrl="/changelog/" />
+<ChangelogFeedPage page={page} baseUrl="/changelog" />

--- a/src/pages/changelog/post/[slug].astro
+++ b/src/pages/changelog/post/[slug].astro
@@ -46,7 +46,7 @@ const { Content } = await render(entry);
   }}
 >
   <div class="changelog-post not-content">
-    <p class="back-link"><a href="/changelog/">&larr; Back to the changelog</a></p>
+    <p class="back-link"><a href="/changelog">&larr; Back to the changelog</a></p>
     <p class="post-date">
       <time datetime={entry.data.date.toISOString().slice(0, 10)}>{formatDate(entry.data.date)}</time>
     </p>
@@ -58,7 +58,7 @@ const { Content } = await render(entry);
       (newer || older) && (
         <nav class="post-pager" aria-label="Changelog entries">
           {older ? (
-            <a class="pager-link" href={`/changelog/post/${older.slug}/`} rel="prev">
+            <a class="pager-link" href={`/changelog/post/${older.slug}`} rel="prev">
               <Icon name="left-arrow" />
               <span>
                 <small>Older</small>
@@ -69,7 +69,7 @@ const { Content } = await render(entry);
             <span />
           )}
           {newer && (
-            <a class="pager-link pager-next" href={`/changelog/post/${newer.slug}/`} rel="next">
+            <a class="pager-link pager-next" href={`/changelog/post/${newer.slug}`} rel="next">
               <span>
                 <small>Newer</small>
                 {newer.data.title}

--- a/src/pages/changelog/product/[product]/[...page].astro
+++ b/src/pages/changelog/product/[product]/[...page].astro
@@ -16,4 +16,4 @@ const { page } = Astro.props;
 const product = Astro.params.product as ProductId;
 ---
 
-<ChangelogFeedPage page={page} baseUrl={`/changelog/product/${product}/`} product={product} />
+<ChangelogFeedPage page={page} baseUrl={`/changelog/product/${product}`} product={product} />

--- a/src/pages/changelog/rss.xml.js
+++ b/src/pages/changelog/rss.xml.js
@@ -11,7 +11,7 @@ export async function GET(context) {
       title: `${entry.data.products.map((id) => PRODUCTS[id].name).join(', ')} - ${entry.data.title}`,
       description: entry.data.description,
       pubDate: entry.data.date,
-      link: `/changelog/post/${entry.slug}/`,
+      link: `/changelog/post/${entry.slug}`,
       categories: entry.data.products.map((id) => PRODUCTS[id].name),
     })),
     customData: '<language>en-us</language>',

--- a/src/pages/changelog/rss/[product].xml.js
+++ b/src/pages/changelog/rss/[product].xml.js
@@ -17,7 +17,7 @@ export async function GET(context) {
       title: entry.data.title,
       description: entry.data.description,
       pubDate: entry.data.date,
-      link: `/changelog/post/${entry.slug}/`,
+      link: `/changelog/post/${entry.slug}`,
       categories: entry.data.products.map((id) => PRODUCTS[id].name),
     })),
     customData: '<language>en-us</language>',

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,9 @@
   // from the `redirects` map in astro.config.mjs.
   "assets": {
     "directory": "./dist",
-    "not_found_handling": "404-page"
+    "not_found_handling": "404-page",
+    // Pages build as /path.html (Astro build.format 'file'); /path/ 301s to /path.
+    "html_handling": "drop-trailing-slash"
   },
 
   "routes": [{ "pattern": "docs.streamelements.com", "custom_domain": true }]


### PR DESCRIPTION
Restores URL parity with the old Docusaurus site (slash-less URLs) so existing inbound links and search results resolve directly instead of taking a 301 hop.

- `trailingSlash: 'never'` — Starlight emits slash-less links, canonicals, og:url, and sitemap entries (verified in built output: 0 slashed or `.html` hrefs)
- Output stays in directory format; Cloudflare serves `/path` from `path/index.html` via `html_handling: "drop-trailing-slash"`, and 301s `/path/` → `/path`
- All internal links across content and changelog components updated (~680 lines); links validator green