### PR TITLE
Add cache headers for Workers static assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,36 @@
+# Cache policy for Cloudflare Workers static assets.
+#
+# HTML (and anything not matched below) keeps Cloudflare's default
+# "public, max-age=0, must-revalidate" + ETag, so deploys are visible
+# immediately. Rules must not overlap: Cache-Control values from multiple
+# matching rules are comma-joined, which produces an invalid header.
+
+# Content-hashed build output (CSS/JS/fonts/optimized images) never changes.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Pagefind search index: entry files are not content-hashed, keep it short.
+/pagefind/*
+  Cache-Control: public, max-age=3600
+
+# Unhashed static media.
+/img/*
+  Cache-Control: public, max-age=86400
+/video/*
+  Cache-Control: public, max-age=604800
+
+# Favicon set (replaced rarely; a day of staleness is acceptable).
+/favicon.ico
+  Cache-Control: public, max-age=86400
+/favicon.svg
+  Cache-Control: public, max-age=86400
+/favicon-96x96.png
+  Cache-Control: public, max-age=86400
+/apple-touch-icon.png
+  Cache-Control: public, max-age=86400
+/web-app-manifest-192x192.png
+  Cache-Control: public, max-age=86400
+/web-app-manifest-512x512.png
+  Cache-Control: public, max-age=86400
+/site.webmanifest
+  Cache-Control: public, max-age=86400


### PR DESCRIPTION
Everything currently ships with Cloudflare's default `max-age=0, must-revalidate`, including the content-hashed `/_astro/*` bundles — browsers revalidate every asset on every visit.

- `/_astro/*` → `max-age=31536000, immutable` (content-hashed, safe forever)
- `/pagefind/*` → 1h (entry files aren't hashed)
- `/img/*` 1d, `/video/*` 7d, favicon set 1d
- HTML and anything unmatched keeps the default revalidation + ETag so deploys are visible immediately

Verified in `wrangler dev`: each path class returns the intended Cache-Control, no comma-joined collisions (why there are no extension globs — they'd double-match `/_astro` files).