### PR TITLE
Redirect legacy /sitemap.xml to sitemap-index.xml

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -50,6 +50,10 @@ function emitRedirectsFile() {
           const variants = from.endsWith('/') ? [from] : [from, `${from}/`];
           return variants.map((path) => `${path} ${to} 301`);
         });
+        // Old Docusaurus sitemap location, still registered with search
+        // engines. Edge-only (not in the Astro redirects map): an HTML
+        // meta-refresh page is useless to XML consumers.
+        lines.push('/sitemap.xml /sitemap-index.xml 301');
         fs.writeFileSync(new URL('_redirects', dir), `${lines.join('\n')}\n`);
       },
     },


### PR DESCRIPTION
The old Docusaurus site served its sitemap at /sitemap.xml, and search consoles still have that URL registered — it has been 404ing since the cutover. Adds an edge 301 to /sitemap-index.xml via the _redirects emitter (edge-only: an HTML meta-refresh page would be useless to XML consumers).