### PR TITLE
Revert the /sitemap.xml redirect

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -50,10 +50,6 @@ function emitRedirectsFile() {
           const variants = from.endsWith('/') ? [from] : [from, `${from}/`];
           return variants.map((path) => `${path} ${to} 301`);
         });
-        // Old Docusaurus sitemap location, still registered with search
-        // engines. Edge-only (not in the Astro redirects map): an HTML
-        // meta-refresh page is useless to XML consumers.
-        lines.push('/sitemap.xml /sitemap-index.xml 301');
         fs.writeFileSync(new URL('_redirects', dir), `${lines.join('\n')}\n`);
       },
     },


### PR DESCRIPTION
Reverts #92 per discussion — no redirect needed. robots.txt's `Sitemap:` directive is the native discovery mechanism and already advertises `/sitemap-index.xml` (verified live); resubmitting the sitemap in Search Console covers any console still pinned to the old URL.