### PR TITLE
Cut AI-boilerplate prose from variable, module, and topic pages

### DIFF
--- a/src/content/docs/chatbot/commands/default/8ball.mdx
+++ b/src/content/docs/chatbot/commands/default/8ball.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!8ball` command simulates a magic 8-ball toy, providing random responses to viewer questions. This interactive feature engages your audience and adds an element of unpredictability to your chat.
+The `!8ball` command simulates a magic 8-ball toy: ask it a question and it answers with a random verdict.
 
 ## Usage
 

--- a/src/content/docs/chatbot/commands/default/accountage.mdx
+++ b/src/content/docs/chatbot/commands/default/accountage.mdx
@@ -14,7 +14,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!accountage` command allows users to check the creation date (age) of a Twitch account. This tool is particularly useful for moderators to verify user authenticity or determine eligibility for certain privileges based on account age.
+The `!accountage` command shows how old a Twitch account is — a quick way for moderators to spot freshly created accounts.
 
 ## Usage
 

--- a/src/content/docs/chatbot/commands/default/addpoints.mdx
+++ b/src/content/docs/chatbot/commands/default/addpoints.mdx
@@ -15,7 +15,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `!addpoints` command allows streamers and moderators to manually add points to a specific viewer's balance within the StreamElements loyalty system. This is useful for rewarding viewers for actions outside the standard point triggers, correcting point balances, or running special promotions.
+The `!addpoints` command manually adds loyalty points to a viewer's balance — for one-off rewards or for correcting a balance.
 
 ## Usage
 

--- a/src/content/docs/chatbot/filters/caps.md
+++ b/src/content/docs/chatbot/filters/caps.md
@@ -21,8 +21,4 @@ The Caps filter helps manage the use of capital letters in chat messages. It che
 | Minimum characters | The minimum number of characters a message must have before the filter checks for a violation. If a message contains fewer characters than this limit, it will not be checked by the filter. |
 | Maximum percent | The maximum percentage of a message that can be capital letters. If the percentage of capital letters in a message exceeds this limit, it will be flagged by the filter. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
-
-## What happens on a violation
-
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).

--- a/src/content/docs/chatbot/filters/emotes.md
+++ b/src/content/docs/chatbot/filters/emotes.md
@@ -19,8 +19,4 @@ The Emote filter helps manage the use of emotes in chat messages. It checks the 
 |---------|-------------|
 | Maximum amount | The maximum number of emotes allowed in a message. If a message contains more emotes than this limit, it will be flagged by the filter. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
-
-## What happens on a violation
-
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).

--- a/src/content/docs/chatbot/filters/index.mdx
+++ b/src/content/docs/chatbot/filters/index.mdx
@@ -14,7 +14,7 @@ keywords:
 
 import { CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
 
-Spam filters are essential tools for maintaining a clean and enjoyable chat environment during your streams. StreamElements Chatbot offers various types of filters to help you automatically moderate messages and protect your chat from unwanted content.
+Spam filters automatically moderate chat messages so you don't have to catch everything yourself. Each filter targets one kind of unwanted message — caps, links, banned words, spam — and takes a configurable action when a message matches.
 
 ## Usage
 

--- a/src/content/docs/chatbot/filters/language.md
+++ b/src/content/docs/chatbot/filters/language.md
@@ -21,8 +21,4 @@ The Language filter moderates messages based on the language they are written in
 | Minimum percentage | The minimum detection confidence. Messages whose language can't be identified with at least this confidence are flagged. |
 | Excluded characters | Phrases stripped from a message before language detection runs (useful for emote names and channel-specific slang that confuse detection). |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
-
-## What happens on a violation
-
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).

--- a/src/content/docs/chatbot/filters/links.md
+++ b/src/content/docs/chatbot/filters/links.md
@@ -23,10 +23,6 @@ The Link filter helps manage the posting of links in chat messages. It checks if
 
 Both lists support the `*` wildcard character for flexible rules, and patterns are matched case-insensitively.
 
-The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
-
-## What happens on a violation
-
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).
 
 Links matching the blocklist receive a harsher punishment: when the action is a timeout, the user is timed out for **double** the configured duration. With any other action (delete only, ban, or warning), the configured action applies as-is.

--- a/src/content/docs/chatbot/filters/one-man-spam.md
+++ b/src/content/docs/chatbot/filters/one-man-spam.md
@@ -22,8 +22,4 @@ The One-Man Spam filter targets spam coming from a single user. Instead of judgi
 | Lookback | How many seconds of the user's message history are inspected. |
 | Threshold | The message similarity score (0–1, decimals allowed) that causes the user to be timed out. Messages at or above this similarity count as spam. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
-
-## What happens on a violation
-
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).

--- a/src/content/docs/chatbot/filters/paragraph.md
+++ b/src/content/docs/chatbot/filters/paragraph.md
@@ -20,8 +20,4 @@ The Paragraph filter helps manage the length of chat messages. It checks the num
 |---------|-------------|
 | Maximum amount | The maximum number of characters allowed in a message. If a message contains more characters than this limit, it will be flagged by the filter. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
-
-## What happens on a violation
-
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).

--- a/src/content/docs/chatbot/filters/repetition.md
+++ b/src/content/docs/chatbot/filters/repetition.md
@@ -20,8 +20,4 @@ The Repetition filter limits how often the same word may be repeated within a si
 | Maximum word repetitions | The maximum number of times a word can occur in a single message. |
 | Minimum characters | Words shorter than this are ignored when counting repetitions. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
-
-## What happens on a violation
-
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).

--- a/src/content/docs/chatbot/filters/symbol.md
+++ b/src/content/docs/chatbot/filters/symbol.md
@@ -21,8 +21,4 @@ The Symbol filter helps manage the use of symbols in chat messages. It checks th
 | Minimum amount | The minimum number of symbols a message must have before the filter checks for a violation. If a message contains fewer symbols than this limit, it will not be checked by the filter. |
 | Maximum percent | The maximum percentage of a message that can be symbols. If the percentage of symbols in a message exceeds this limit, it will be flagged by the filter. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
-
-## What happens on a violation
-
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).

--- a/src/content/docs/chatbot/filters/zalgo.md
+++ b/src/content/docs/chatbot/filters/zalgo.md
@@ -19,8 +19,4 @@ The Zalgo filter removes "zalgo" text — messages distorted with stacked combin
 |---------|-------------|
 | Maximum amount | The maximum number of zalgo (combining) characters allowed in a single message. |
 
-The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters), including the timeout length, custom timeout message, and excluded user level.
-
-## What happens on a violation
-
-The filter's timeout setting determines the action: a timeout for the configured number of seconds, message deletion only (timeout of 0), a permanent ban, or a warning plus deletion (Twitch only). See [What happens on a violation](/chatbot/filters#what-happens-on-a-violation) for details.
+The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).

--- a/src/content/docs/chatbot/modules/chatalerts.md
+++ b/src/content/docs/chatbot/modules/chatalerts.md
@@ -21,7 +21,7 @@ keywords:
 - Twitch community engagement
 ---
 
-The Chat Alerts module is a powerful feature of the StreamElements chatbot that automatically posts messages in your chat when specific events occur. This helps streamers acknowledge viewer actions, enhance engagement, and keep the community informed about important stream events.
+The Chat Alerts module automatically posts a chat message when something happens on your channel — a follow, a subscription, a raid, and so on — so events get acknowledged even when you're mid-game.
 
 ## Usage
 

--- a/src/content/docs/chatbot/modules/emotecombo.mdx
+++ b/src/content/docs/chatbot/modules/emotecombo.mdx
@@ -19,7 +19,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The Emote Combo feature is an interactive chat module that encourages viewers to create chains of consecutive emotes. It adds a fun, engaging element to your stream by challenging viewers to maintain and extend emote streaks.
+The Emote Combo module tracks chains of consecutive messages containing the same emote, and announces the streak when someone finally breaks it.
 
 ## How It Works
 

--- a/src/content/docs/chatbot/modules/emotepyramid.mdx
+++ b/src/content/docs/chatbot/modules/emotepyramid.mdx
@@ -17,7 +17,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The Emote Pyramid is an engaging chat game that encourages viewer participation and creates a fun atmosphere in your stream. Players attempt to collaboratively build a pyramid of emotes in the chat, increasing the challenge and excitement as the pyramid grows.
+The Emote Pyramid module is a chat game where viewers build a pyramid out of a single emote — one emote, then two, up to a peak and back down — and the bot announces whoever sends the message that completes it.
 
 ## How It Works
 

--- a/src/content/docs/chatbot/modules/index.mdx
+++ b/src/content/docs/chatbot/modules/index.mdx
@@ -17,7 +17,7 @@ keywords:
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-Chatbot modules are a set of powerful tools designed to enhance viewer interaction and engagement in your live stream. These modules provide a wide range of functionalities that can be customized to fit the unique needs of your stream and community.
+Chatbot modules are optional features you can switch on per channel — chat games like roulette and bingo, automated chat alerts, raffles, and moderation helpers like votekick.
 
 ## Usage
 

--- a/src/content/docs/chatbot/modules/roulette.md
+++ b/src/content/docs/chatbot/modules/roulette.md
@@ -21,7 +21,7 @@ keywords:
 - point system for streams
 ---
 
-The Roulette module is an interactive chat game that allows users to wager their points in a roulette-style gamble. It adds excitement and engagement to your stream by giving viewers a chance to win or lose points based on luck.
+The Roulette module is a chat game where viewers wager loyalty points on a spin: win and you gain your wager, lose and it's gone.
 
 ## Usage
 

--- a/src/content/docs/chatbot/modules/slotmachine.md
+++ b/src/content/docs/chatbot/modules/slotmachine.md
@@ -16,7 +16,7 @@ keywords:
 - chat-based gambling simulator
 ---
 
-The Slotmachine module is an interactive chat game that allows viewers to wager their points on a virtual slot machine. Players can win or lose points based on the outcome of the spin, adding an element of excitement to the stream chat.
+The Slotmachine module is a chat game where viewers wager loyalty points on a spin of a virtual slot machine.
 
 ## Usage
 

--- a/src/content/docs/chatbot/modules/votekick.md
+++ b/src/content/docs/chatbot/modules/votekick.md
@@ -16,7 +16,7 @@ keywords:
 - temporary user removal
 ---
 
-The Votekick module is a powerful chatbot feature that enables viewers to vote on whether to temporarily remove a user from the chat. If the vote passes, the user is timed out in chat for the configured duration.
+The Votekick module lets viewers vote on whether to temporarily remove a user from the chat. If the vote passes, the user is timed out for the configured duration.
 
 ## Usage
 

--- a/src/content/docs/chatbot/variables/ai.mdx
+++ b/src/content/docs/chatbot/variables/ai.mdx
@@ -13,7 +13,7 @@ arguments: required
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(ai)` variable allows you to integrate AI into your StreamElements chat commands, generating dynamic responses based on user input. This powerful feature can enhance viewer engagement and create unique interactive experiences in your stream.
+The `$(ai)` variable allows you to integrate AI into your StreamElements chat commands, generating dynamic responses based on user input.
 
 :::caution
 The `$(ai)` variable is currently in beta and may be subject to changes.
@@ -107,22 +107,6 @@ When the limit is exceeded, the bot replies `rate limit exceeded`.
 :::note
 AI replies are sanitized before being sent to chat: leading `/` and `.` characters are stripped, and replies starting with `!` are prefixed with an invisible character — so an AI response can never trigger chat commands or other bot commands.
 :::
-
-## Best Practices
-
-1. Provide clear context in your queries to get more relevant responses.
-2. Use command cooldowns to prevent spam.
-3. Combine the `$(ai)` variable with other StreamElements variables for more dynamic interactions.
-4. Test your AI commands thoroughly before using them in live streams.
-
-## Troubleshooting
-
-If you're experiencing issues with the `$(ai)` variable, try the following:
-
-1. Check your rate limit usage and wait for the reset if necessary.
-2. Verify that your command syntax is correct.
-3. Ensure that your StreamElements bot has the necessary permissions in your chat.
-4. If problems persist, reach out to StreamElements support for further assistance.
 
 ## FAQ
 

--- a/src/content/docs/chatbot/variables/channel.mdx
+++ b/src/content/docs/chatbot/variables/channel.mdx
@@ -89,17 +89,6 @@ The standalone [`$(game)`](/chatbot/variables/game), [`$(title)`](/chatbot/varia
    We've been live for 3 hours 27 mins with 1337 viewers and 850 active chatters!
    ```
 
-## Best Practices
-
-1. Use channel variables to provide real-time information about your stream in chat commands.
-2. Combine multiple variables to create comprehensive stream status messages.
-3. Always provide clear examples and explanations when creating custom commands using these variables.
-
-## Troubleshooting
-
-- If a variable returns unexpected results, ensure you're using the correct syntax.
-- Remember that some variables may return specific values when the stream is offline or information is not available.
-
 ## Related Variables
 
 - [$(user)](/chatbot/variables/user): Displays information about the user who triggered the command

--- a/src/content/docs/chatbot/variables/count.mdx
+++ b/src/content/docs/chatbot/variables/count.mdx
@@ -15,7 +15,7 @@ arguments: optional
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(count)` variable is a versatile tool in the StreamElements Chatbot that allows you to create, display, and manipulate custom counters for various purposes in your stream. It's commonly used for tracking deaths in games, counting command usage, or keeping score of any recurring event.
+The `$(count)` variable creates, displays, and changes named counters. It's commonly used for tracking deaths in games, counting command usage, or keeping score of any recurring event.
 
 ## Use it
 

--- a/src/content/docs/chatbot/variables/customapi.mdx
+++ b/src/content/docs/chatbot/variables/customapi.mdx
@@ -14,7 +14,7 @@ arguments: required
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(customapi)` variable enables you to make HTTP requests to external APIs and display the responses directly in your stream's chat. This powerful feature allows you to integrate real-time data from various sources into your chat messages and commands.
+The `$(customapi)` variable makes an HTTP request to an external API and displays the response directly in chat. Use it to pull real-time data — game stats, third-party services, or your own endpoints — into commands.
 
 ## Use it
 

--- a/src/content/docs/chatbot/variables/game.mdx
+++ b/src/content/docs/chatbot/variables/game.mdx
@@ -14,7 +14,7 @@ arguments: optional
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(game)` variable is a powerful tool that allows you to display the current game being played on a Twitch channel. This variable is particularly useful for creating dynamic commands or messages that reference the streamer's current activity.
+The `$(game)` variable displays the game category a channel is currently playing.
 
 :::note
 `$(game)` is not available on YouTube — there, it renders as literal text instead of being replaced. On YouTube, use [`$(channel.game)`](/chatbot/variables/channel) instead, which works on every platform.

--- a/src/content/docs/chatbot/variables/index.md
+++ b/src/content/docs/chatbot/variables/index.md
@@ -16,7 +16,7 @@ Chat commands support variables in a dynamic way. Variables are placeholders tha
 
 For example, in the command `$(uptime shroud)`, `shroud` is a variable representing a username. When this command is executed, the `uptime` of the user `shroud` is returned.
 
-Variables make chat commands more flexible and powerful, allowing for a wide range of interactions and functionalities.
+Variables are placeholders you put in a command response; the bot replaces them with live values — the sender's name, the current game, a random number — when the command runs.
 
 :::tip[In a hurry?]
 See the [Variables cheat sheet](/chatbot/variables/cheat-sheet) — every variable with its syntax and return value on a single page.

--- a/src/content/docs/chatbot/variables/msgid.mdx
+++ b/src/content/docs/chatbot/variables/msgid.mdx
@@ -13,7 +13,7 @@ arguments: none
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(msgid)` variable is a powerful tool in the StreamElements Chatbot that outputs the unique message ID of the message that triggered a command. This can be useful for tracking specific messages, debugging, or creating advanced custom functionality in your stream.
+The `$(msgid)` variable outputs the unique message ID of the chat message that triggered the command — mainly useful for debugging and advanced custom integrations.
 
 ## Use it
 

--- a/src/content/docs/chatbot/variables/pointsname.mdx
+++ b/src/content/docs/chatbot/variables/pointsname.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(pointsname)` variable is a dynamic way to display the current name of your stream's loyalty currency in chat messages or commands. It automatically updates to reflect your custom points system name, providing a flexible solution for referencing your loyalty program.
+The `$(pointsname)` variable displays the name of your channel's loyalty currency, so command responses keep working even after you rename your points.
 
 ## Use it
 

--- a/src/content/docs/chatbot/variables/random.mdx
+++ b/src/content/docs/chatbot/variables/random.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-StreamElements offers a set of powerful random variables that allow you to generate dynamic, randomized content in your stream chat. These variables are essential tools for creating engaging interactions, mini-games, and surprise elements that keep your audience entertained and involved.
+StreamElements provides a set of random variables: random numbers in a range, a random pick from a list, a random emote, and a random active chatter. They're the building blocks for mini-games and giveaway-style commands.
 
 ## Use it
 

--- a/src/content/docs/chatbot/variables/sender.mdx
+++ b/src/content/docs/chatbot/variables/sender.mdx
@@ -83,16 +83,6 @@ Durations are written out in full words: `secs`, `mins`, `hours`, `days`, `month
 
 `$(source)` can also be used as an alias for `$(sender)`.
 
-## Best Practices
-
-1. Use `$(sender)` when you only need information about the command trigger.
-2. If you need to reference other users or allow flexible user queries, use the [`$(user)`](/chatbot/variables/user) variable instead.
-
-## Troubleshooting
-
-- If a variable returns unexpected results, ensure you're using the correct syntax and that the user exists in your channel's database.
-- Remember that `$(sender)` variables don't accept arguments. If you need to query other users, use `$(user)` instead.
-
 ## Related Variables
 
 - [`$(user)`](/chatbot/variables/user): Query information about any user, not just the command sender.

--- a/src/content/docs/chatbot/variables/settitle.mdx
+++ b/src/content/docs/chatbot/variables/settitle.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(settitle)` variable allows you to change your stream title directly from chat. This powerful feature helps streamers quickly update their broadcast information without leaving the game or interrupting their content. On success, it outputs the new title.
+The `$(settitle)` variable changes your stream title from within a command response. On success, it outputs the new title.
 
 ## Use it
 

--- a/src/content/docs/chatbot/variables/time.mdx
+++ b/src/content/docs/chatbot/variables/time.mdx
@@ -104,25 +104,7 @@ The result is a human-readable duration such as `2 hours 30 mins`. If the target
    Upcoming event in $(time.until 2026-09-20T19:00:00-03:00)
    ```
 
-## Common Use Cases
-
-1. **Displaying Local Time**: Use `$(time <timezone>)` to show the streamer's local time or the time in different viewers' locations.
-
-2. **Event Countdowns**: Use `$(time.until)` to create excitement for upcoming streams, game releases, or special events.
-
-3. **Multi-Timezone Scheduling**: Display multiple timezones simultaneously for international audiences.
-
-4. **Dynamic Stream Information**: Incorporate time variables into stream titles or chat commands to provide real-time updates.
-
-## Best Practices
-
-1. Always use IANA timezone names with `$(time)` to ensure accuracy and avoid ambiguity.
-2. With `$(time.until)`, stick to the two supported formats — a bare `HH:MM` time or a full RFC 3339 timestamp.
-3. Consider creating custom commands that combine both variables for comprehensive time information.
-
-## Troubleshooting
-
-### Common Errors
+## Common errors
 
 1. **Invalid Timezone**:
    - Error message: `unknown time zone lol`
@@ -134,14 +116,6 @@ The result is a human-readable duration such as `2 hours 30 mins`. If the target
 
 ## FAQ
 
-**Q: Can I use these variables in custom commands?**
-
-A: Yes, you can incorporate these time variables into your custom chat commands for added functionality.
-
-**Q: How often do the time variables update?**
-
-A: The variables update in real-time with each use, providing current information every time they're called.
-
 **Q: Can I use abbreviations like EST or GMT with $(time)?**
 
 A: No, always use full IANA timezone names like "America/New_York" or "Europe/London" to avoid ambiguity and ensure correct time display.
@@ -149,7 +123,3 @@ A: No, always use full IANA timezone names like "America/New_York" or "Europe/Lo
 **Q: What timezone does $(time.until 19:00) use?**
 
 A: Bare times are always interpreted as UTC. To count down to a time in your local timezone, use a full RFC 3339 timestamp with a UTC offset, e.g. `2026-09-20T19:00:00-03:00`.
-
-## Additional Resources
-
-- [IANA Time Zone Database](https://www.iana.org/time-zones)

--- a/src/content/docs/chatbot/variables/touser.mdx
+++ b/src/content/docs/chatbot/variables/touser.mdx
@@ -13,7 +13,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(touser)` variable is a versatile tool in the StreamElements Chatbot that displays the first word after a command, falling back to the sender's name. It's particularly useful for creating personalized responses or directing messages to specific users.
+The `$(touser)` variable displays the first word typed after a command, falling back to the sender's name — handy for shoutouts and any command aimed at a specific user.
 
 ## Use it
 

--- a/src/content/docs/chatbot/variables/twitchemotes.mdx
+++ b/src/content/docs/chatbot/variables/twitchemotes.mdx
@@ -12,7 +12,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(twitchemotes)` variable is a powerful tool that allows you to display all available Twitch subscriber emotes in your stream chat. This can be useful for showcasing your channel's unique emotes or creating interactive chat experiences.
+The `$(twitchemotes)` variable lists a channel's Twitch subscriber emotes in chat.
 
 ## Use it
 

--- a/src/content/docs/chatbot/variables/uptime.mdx
+++ b/src/content/docs/chatbot/variables/uptime.mdx
@@ -12,7 +12,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(uptime)` variable is a powerful tool in the StreamElements Chatbot that displays the duration of the current stream for a specified user. This feature is particularly useful for viewers who want to know how long a stream has been live.
+The `$(uptime)` variable displays how long a channel's current stream has been live.
 
 ## Use it
 

--- a/src/content/docs/chatbot/variables/user.mdx
+++ b/src/content/docs/chatbot/variables/user.mdx
@@ -101,16 +101,9 @@ Durations are written out in full words: `secs`, `mins`, `hours`, `days`, `month
    ModUser has 100 points and is rank 5/283 on the leaderboard
    ```
 
-## Best Practices
-
-1. Use `$(user)` without arguments when you need information about the command trigger.
-2. Use `$(user username)` when you need to reference other users or allow flexible user queries.
-3. Always provide clear examples and explanations when creating custom commands using these variables.
-
-## Troubleshooting
-
-- If a variable returns unexpected results, ensure you're using the correct syntax and that the user exists in your channel's database. Unknown users produce empty output.
-- Remember that `$(user)` variables can accept arguments. If you only need information about the command sender, consider using [`$(sender)`](/chatbot/variables/sender) instead.
+:::note
+Lookups only work for users the bot has seen in your channel — unknown users produce empty output.
+:::
 
 ## Related Variables
 

--- a/src/content/docs/chatbot/variables/weather.mdx
+++ b/src/content/docs/chatbot/variables/weather.mdx
@@ -14,7 +14,7 @@ keywords:
 
 import ChatExample from '@components/ChatExample.astro';
 
-The `$(weather)` variable allows you to display current weather conditions for a specified location in your StreamElements chatbot. It provides comprehensive information including temperature, feels-like temperature, weather description, wind details, humidity, visibility, and air pressure.
+The `$(weather)` variable displays current weather conditions for a location: temperature, feels-like temperature, conditions, wind, humidity, visibility, and air pressure.
 
 :::caution
 Weather data is provided by third-party sources and may not reflect current geopolitical boundaries.
@@ -30,16 +30,6 @@ Weather data is provided by third-party sources and may not reflect current geop
   { persona: 'user', message: '!weather Berlin' },
   { persona: 'bot', message: 'Berlin, Germany: 🌞 21.0 °C (69.8 °F). Feels like 20.4 °C (68.7 °F). Partly cloudy. Wind is blowing from the Northwest at 10.1 km/h (6.3 mp/h). 50% humidity. Visibility: 10 km (6 miles). Air pressure: 1013 hPa.' }
 ]} />
-
-## Usage
-
-To use the `$(weather)` variable, follow this syntax:
-
-```streamelements
-$(weather "<location>")
-```
-
-Replace `<location>` with the desired city and state/country.
 
 :::note
 `$(weather)` only uses the first word it is given, so multi-word locations must be passed as a single token: wrap the location in quotes, or nest an argument token like `${1:}` (as in the example above) so everything the viewer types arrives as one piece.

--- a/src/content/docs/overlays/custom-code-in-alertbox.md
+++ b/src/content/docs/overlays/custom-code-in-alertbox.md
@@ -17,7 +17,7 @@ This article requires you to have an Overlay created with an AlertBox with "Cust
 
 ## Custom Code Editor
 
-The Custom Code Editor is a powerful tool that allows you to write custom code in the Overlay Editor. For more information about the Custom Code Editor, please refer to the [Code Editor](/overlays/widget-structure) article.
+Custom code is written in the Overlay Editor's Code Editor — see the [Code Editor](/overlays/widget-structure) article for the tabs and structure.
 
 ## Inline Variables available
 

--- a/src/content/docs/overlays/custom-widget.md
+++ b/src/content/docs/overlays/custom-widget.md
@@ -24,7 +24,7 @@ This article requires you to have an Overlay created with a Custom Widget added 
 
 ### Custom Code Editor
 
-The Custom Code Editor is a powerful tool that allows you to write custom code in the Overlay Editor. For more information about the Custom Code Editor, please refer to the [Code Editor](/overlays/widget-structure) article.
+Custom code is written in the Overlay Editor's Code Editor — see the [Code Editor](/overlays/widget-structure) article for the tabs and structure.
 
 ## SE_API
 

--- a/src/content/docs/overlays/index.mdx
+++ b/src/content/docs/overlays/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overlays
-description: "Create engaging stream overlays with StreamElements: Custom widgets, alerts, and more for Twitch and YouTube Live."
+description: "Build stream overlays with StreamElements: the Overlay Editor, AlertBox, and fully custom-coded widgets for Twitch and YouTube Live."
 keywords:
   - StreamElements Overlays
   - Custom stream widgets
@@ -13,7 +13,7 @@ keywords:
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-Welcome to the StreamElements Overlays documentation. This guide will help you create engaging and interactive overlays for your Twitch or YouTube Live streams using our powerful Overlay Editor and custom widgets.
+Overlays are the visuals layered on top of your stream — alerts, labels, goals, chat — composed in the StreamElements Overlay Editor and rendered in your broadcast software via a single browser source. When the built-in widgets aren't enough, you can code your own.
 
 ## For streamers
 

--- a/src/content/docs/websockets/topics/channel-contests.md
+++ b/src/content/docs/websockets/topics/channel-contests.md
@@ -11,7 +11,7 @@ keywords:
 - real-time
 ---
 
-This topic provides real-time contest and prediction events published to Astro for WebSocket delivery. It covers contest state changes, vote/bet updates, and winner announcements. Subscribe to this topic to receive notifications about contest activities, allowing you to build real-time prediction displays, betting interfaces, or sync contest state across multiple clients.
+This topic carries contest and prediction events: state changes, vote/bet updates, and winner announcements.
 
 ## Payload
 

--- a/src/content/docs/websockets/topics/channel-giveaway.md
+++ b/src/content/docs/websockets/topics/channel-giveaway.md
@@ -10,7 +10,7 @@ keywords:
 - real-time data
 ---
 
-This topic provides real-time updates for giveaway events. It covers the full giveaway lifecycle including starting, entries, winner selection, closing, and refunds. Subscribe to this topic to receive notifications about giveaway activities, allowing you to build real-time giveaway displays or sync giveaway state across multiple clients.
+This topic carries the full giveaway lifecycle: starting, entries, winner selection, closing, and refunds.
 
 ## Payload
 

--- a/src/content/docs/websockets/topics/channel-songrequest.md
+++ b/src/content/docs/websockets/topics/channel-songrequest.md
@@ -13,7 +13,7 @@ keywords:
 - real-time
 ---
 
-This topic provides real-time songrequest events published to Astro for WebSocket delivery. It covers all songrequest-related actions including player controls, queue management, history tracking, song playback, and settings updates. Subscribe to this topic to receive notifications about songrequest activities, allowing you to build real-time songrequest displays, queue management interfaces, or sync songrequest state across multiple clients.
+This topic carries every songrequest event: player controls, queue changes, history, song playback, and settings updates.
 
 ## Payload
 


### PR DESCRIPTION
Part 2 of 3 (stacked on #94 — retarget to master after it merges).

Deletion-first pass on the machine-fingerprint prose (net −120 lines):

- Deleted the stamped **Best Practices / Troubleshooting** sections on variable pages (`channel`, `user`, `sender`, `ai`, `time`) — they restated definitions as advice, with identical sentences across pages. The one real fact each contained (e.g. unknown users → empty output, `time` error strings) was kept and folded into the page proper.
- Rewrote the **"powerful/versatile tool" openers** (~15 pages) into plain factual sentences.
- Replaced the **fill-in-the-blank intros** on the contests/songrequest/giveaway websocket topics ("build real-time X displays, Y interfaces, or sync X state…").
- `weather`: merged the duplicate "Use it"/"Usage" sections; `time`: collapsed five padding sections into Common errors + a 2-question FAQ.
- Deduped the identical "What happens on a violation" paragraph pasted on 9 filter pages — now one line pointing at the shared section.
- `overlays/index`: replaced the "Welcome… powerful Overlay Editor" boilerplate with a description of what overlays actually are.

Kept: "powerful command, use with caution" on `!nuke`/`!nukeusername` (that's a real warning), and borderline-but-human phrasing elsewhere.

🤖 Generated with Claude Code