### PR TITLE
Dashboard-verified spam filter docs: protection levels and Penalty model

### DIFF
--- a/src/content/docs/chatbot/filters/index.mdx
+++ b/src/content/docs/chatbot/filters/index.mdx
@@ -22,16 +22,14 @@ To use spam filters, you need to enable and configure them in your StreamElement
 
 ## Configuration
 
-To configure spam filters:
+Filters live in the dashboard under **Chatbot → Spam filters**. The quickest way to start is the protection-level slider at the top of the page — **Filters off**, **Minimum**, **Medium**, or **Maximum** — which applies a preset configuration across the filters. From there, expand any individual filter to toggle it and fine-tune its settings.
 
 <Steps>
 
-1. Log in to your StreamElements dashboard
-2. Navigate to the Chatbot section
-3. Select "Spam Filters" from the menu
-4. Choose the filter type you want to set up
-5. Adjust the settings according to your preferences
-6. Save your changes
+1. In the dashboard, go to **Chatbot → Spam filters**
+2. Pick a protection level as your starting point
+3. Expand a filter to adjust its penalty, thresholds, announcements, and probation
+4. Toggle the filter on
 
 </Steps>
 
@@ -42,24 +40,25 @@ In addition to its own thresholds, every filter supports these common settings:
 | Setting | Description |
 |---------|-------------|
 | Enabled | Turns the filter on or off. |
-| Exclude | A user-level threshold. Users at or above the selected level (for example, Moderators and above) bypass the filter entirely. |
-| Timeout length | How long (in seconds) a user is timed out for a violation. This setting also selects the other available actions — see [What happens on a violation](#what-happens-on-a-violation). |
-| Timeout message | A custom message describing the violation. It doubles as the moderation reason attached to the timeout or ban, and as the announcement text. |
-| Announcement | When enabled, the bot also replies in chat with `@username, <your timeout message>`. Each filter has its own announcement cooldown (in seconds) so chat isn't flooded with repeated announcements. |
-| Probation | Escalates punishments for repeat offenders: when a user violates the same filter again within the probation window, the timeout becomes the base timeout × the configured multiplier × the user's number of violations. Probation only escalates timeouts — it never applies to deletions, bans, or warnings. |
+| Penalty | The action taken when the filter is triggered: **Timeout user**, **Ban user**, **Delete message**, or **Warn and delete message** — see [What happens on a violation](#what-happens-on-a-violation). |
+| Duration | How long (in seconds) a user is timed out for, when the penalty is a timeout. |
+| Exclude user group | Users in the selected group or above — Regulars, Subscribers, or VIPs — are immune to the filter. Choose "No One" to apply it to everyone. |
+| Custom message | A custom violation message. It doubles as the moderation reason attached to the timeout or ban, and as the announcement text. |
+| Announcement settings | When enabled, the bot also sends a public warning in chat — `@username, <your custom message>` — when the filter is triggered. Each filter has its own announcement cooldown (in seconds) so chat isn't flooded with repeated announcements. |
+| Probation settings | Escalates punishments for repeat offenders: when a user violates the same filter again within the probation window, the timeout becomes the base timeout × the configured multiplier × the user's number of violations. Probation only escalates timeouts — it never applies to deletions, bans, or warnings. |
 
-The moderation reason sent to the platform is your timeout message with " - automated by StreamElements" appended; the chat announcement uses the message as-is.
+The moderation reason sent to the platform is your custom message with " - automated by StreamElements" appended; the chat announcement uses the message as-is.
 
 Filters never apply to the channel owner or to platform staff. Moderators can also use the [!permit](/chatbot/commands/default/permit) command to give a user a 30-second pass that bypasses all filters.
 
 ## What happens on a violation
 
-The **Timeout length** setting controls what the bot does when a message violates a filter:
+The **Penalty** setting controls what the bot does when a message violates a filter:
 
-- **Timeout** — set a duration in seconds to time the user out and remove the message.
-- **Delete only** — set the timeout to 0 to remove the message without timing the user out.
-- **Permanent ban** — permanently ban the user.
-- **Warn** — issue a Twitch Warning and delete the message.
+- **Timeout user** — time the user out for the configured Duration and remove the message.
+- **Delete message** — remove the message without timing the user out.
+- **Ban user** — permanently ban the user.
+- **Warn and delete message** — issue a Twitch Warning and delete the message.
 
 :::note
 Warnings are a Twitch feature. On other platforms the warn action is unavailable, so pick a timeout, deletion, or ban instead.


### PR DESCRIPTION
Part 4 of the stack (merge after #96). Findings from a read-only sweep of the live dashboard with Claude in Chrome, verifying the docs against what streamers actually see.

- **Protection levels documented**: the Spam Filters page's headline feature — the Filters off / Minimum / Medium / Maximum preset slider — wasn't mentioned anywhere in the docs. The Configuration section now leads with it and the steps match the real flow (expand a filter → General settings / Filter settings / Announcement / Probation).
- **Penalty model corrected**: the docs described the legacy "Timeout length encodes the action (0 = delete only)" mechanism. The current UI has an explicit **Penalty** dropdown (Timeout user / Ban user / Delete message / Warn and delete message) plus a separate **Duration** field. The shared-settings table and "What happens on a violation" now describe that.
- **Labels matched to the UI**: "Exclude" → "Exclude user group" (Regulars / Subscribers / VIPs / No One), "Timeout message" → "Custom message", "Announcement/Probation settings" as shown.

Related dashboard-verified fixes landed on their own branches: filter defaults + the One-Man Spam threshold scale (0–100, not 0–1) on #94, and module-page label alignment ("Max Tickets", contest duration) on #97. Also confirmed in the sweep: no Language filter in the UI (as #94 states), the Modules page shows exactly the 12 documented cards, and all dashboard paths referenced in the docs (Loyalty → Giveaways / Contests / Loyalty settings) are correct.

🤖 Generated with Claude Code