### PR TITLE
Followage page: SERP title and description for search intent

### DIFF
--- a/src/content/docs/chatbot/commands/default/followage.mdx
+++ b/src/content/docs/chatbot/commands/default/followage.mdx
@@ -1,6 +1,10 @@
 ---
 title: "!followage"
-description: "Use the !followage command in StreamElements chatbot to check how long a user has been following a Twitch channel."
+description: "Check how long you — or anyone — have been following a Twitch channel with the free !followage chat command in StreamElements Chatbot."
+# Search-friendly <title>; the on-page H1 stays !followage.
+head:
+  - tag: title
+    content: "Twitch Followage — the !followage Command | StreamElements Docs"
 platforms: [twitch]
 keywords:
   - followage command


### PR DESCRIPTION
Single-page snippet fix for search intent on the followage page.

- `<title>` overridden via frontmatter head (H1 stays `!followage`): **"Twitch Followage — the !followage Command | StreamElements Docs"** — leads with the phrase people search.
- Meta description rewritten to promise the searcher's outcome: "Check how long you — or anyone — have been following a Twitch channel with the free !followage chat command…"

Independent of the other open PRs; merges any time.

🤖 Generated with Claude Code