### PR TITLE
Define what counts as a symbol in the Symbol filter doc

### DIFF
--- a/src/content/docs/chatbot/filters/symbol.md
+++ b/src/content/docs/chatbot/filters/symbol.md
@@ -11,14 +11,24 @@ keywords:
 - timeout settings
 ---
 
-The Symbol filter helps manage the use of symbols in chat messages. It checks the number and percentage of symbols in a message and compares them with the set limits. If a message violates these limits, the filter takes action according to the configured settings.
+The Symbol filter flags messages that contain too many symbols — either more than an absolute number, or making up too large a share of the message.
+
+## What counts as a symbol
+
+Any character that is not a letter, a number, or a space. This includes:
+
+- Punctuation: `!` `?` `.` `,` `"` `'` `@` `#` `&` `(` `)`
+- Math and currency signs: `+` `=` `<` `>` `$` `€` `^` `~`
+- Unicode emoji such as 🎉
+
+Letters and digits from any alphabet, spaces, and accents on letters are never counted. Platform emotes (Twitch, YouTube) are sent as ordinary words like `Kappa`, so they don't count either — only Unicode emoji do.
 
 ## Settings
 
 | Setting | Description |
 |---------|-------------|
-| Maximum amount | The maximum number of symbols allowed in a message. If a message contains more symbols than this limit, it will be flagged by the filter. |
-| Minimum amount | The minimum number of symbols a message must have before the filter checks for a violation. If a message contains fewer symbols than this limit, it will not be checked by the filter. |
-| Maximum percent | The maximum percentage of a message that can be symbols. If the percentage of symbols in a message exceeds this limit, it will be flagged by the filter. |
+| Maximum amount | The most symbols a message may contain. A message with more symbols than this is flagged. |
+| Minimum amount | The minimum message length, in characters, before the filter applies. Messages shorter than this are never flagged, whatever they contain. |
+| Maximum percent | The largest share of a message that may be symbols. The percentage is measured against all characters in the message, spaces included. |
 
 The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).


### PR DESCRIPTION
Closes #84.

The Symbol filter page never said what a "symbol" actually is, so readers couldn't tell whether spaces count (they don't — see the discussion on the issue).

Checked against the filter's actual behaviour and added a short definition: a symbol is any character that isn't a letter, a number, or a space — punctuation, math/currency signs, and Unicode emoji all count. Platform emotes are sent as plain words, so they don't.

Two corrections along the way:
- **Minimum amount** was described as a minimum *symbol* count, but it's really a minimum *message length* gate — messages shorter than it are never checked at all.
- **Maximum percent** now says the percentage is measured against all characters in the message, spaces included.