### PR TITLE
Language filter: correct the confidence semantics, announce the release

### DIFF
--- a/src/content/changelog/chatbot/2026-08-17-language-filter.mdx
+++ b/src/content/changelog/chatbot/2026-08-17-language-filter.mdx
@@ -1,0 +1,11 @@
+---
+title: Language filter
+description: The Language filter is now available in the dashboard. Pick the languages your chat may use, and the bot moderates the rest.
+date: 2026-08-17
+---
+
+The [Language filter](/chatbot/filters/language) is now available under **Chatbot → Spam filters**.
+
+Pick the languages your chat is allowed to use, and the bot moderates messages written in anything else. It detects 75 languages, and you can add emote names and channel slang to **Ignored words** so they never sway the result.
+
+The filter only acts when the detector is sure. Short messages like `gg` or `ok` carry too little signal to identify, so they are left alone rather than punished. **Minimum detection confidence** sets that bar, and defaults to 40%.

--- a/src/content/docs/chatbot/filters/language.md
+++ b/src/content/docs/chatbot/filters/language.md
@@ -11,14 +11,47 @@ keywords:
 - allowed languages
 ---
 
-The Language filter moderates messages based on the language they are written in. A message is flagged when its detected language is not on your allowed list, or when the detection isn't confident enough to tell. When no allowed languages are configured, the filter is off.
+The Language filter moderates messages based on the language they are written in. A message is flagged when the detector is confident about its language and that language is not on your allowed list. When no allowed languages are configured, the filter is off.
 
 ## Settings
 
 | Setting | Description |
 |---------|-------------|
-| Allowed languages | The list of languages permitted in chat (ISO 639-1 codes, e.g. `en`, `de`). An empty list disables the filter. |
-| Minimum percentage | The minimum detection confidence. Messages whose language can't be identified with at least this confidence are flagged. |
-| Excluded characters | Phrases stripped from a message before language detection runs (useful for emote names and channel-specific slang that confuse detection). |
+| Allowed languages | The languages permitted in chat. An empty list disables the filter. |
+| Minimum detection confidence | How sure the detector must be before the filter may act, as a percentage. Messages below this are left alone. Defaults to 40. |
+| Ignored words | Words and phrases stripped from a message before its language is detected, such as emote names and channel slang. |
 
 The filter also supports the [settings shared by all filters](/chatbot/filters#settings-shared-by-all-filters) — timeout length, custom timeout message, excluded user level — which also determine [what happens on a violation](/chatbot/filters#what-happens-on-a-violation).
+
+## How a message is checked
+
+1. Your ignored words are removed from the message, wherever they appear and whatever their casing.
+2. Everything that is not a letter or a space is dropped, so numbers, punctuation, and emoji never sway the result. If nothing is left, the message is skipped.
+3. What remains goes to the language detector, which returns one language and a confidence score.
+4. If that score is below your **Minimum detection confidence**, the message is skipped.
+5. Otherwise the detected language is compared against your allowed list. A match means the message passes; anything else is flagged.
+
+The filter never punishes on doubt. A message it cannot read confidently is left alone, and so is one the detector fails to answer for in time.
+
+## Choosing a confidence value
+
+The detector picks between 75 languages, so its confidence is spread thin on short messages. A two-word message rarely carries enough signal to identify, and the top guess is often nonsense:
+
+| Message | Top guess | Confidence |
+|---------|-----------|------------|
+| `ok` | Zulu | 6.4% |
+| `hi` | Maori | 6.1% |
+| `gg` | Indonesian | 14.4% |
+| `lets gooo` | Tswana | 21.7% |
+| `KEKW PogChamp LULW` | Zulu | 23.1% |
+| `how are you doing today` | English | 45.6% |
+| `hola amigos como estan todos hoy` | Spanish | 47.8% |
+| `ich finde diesen stream richtig gut heute` | German | 86.8% |
+
+Real sentences land around 45% and up. Chat noise sits well below 25%. The default of 40 falls in the gap, which is why short English messages survive in an English-only channel while genuine foreign sentences are caught.
+
+Lower the value and the filter reaches further, at the cost of acting on messages it is guessing about. Raise it and only unmistakable foreign text is flagged.
+
+:::tip
+Add your channel's emote names and catchphrases to **Ignored words**. They are the most common reason an otherwise ordinary message gets read as another language.
+:::


### PR DESCRIPTION
The Language filter page described behaviour that no longer exists, and the filter has only now become reachable for creators, so it also gets a changelog entry.

## The correction

The page said a message is flagged "when the detection isn't confident enough to tell", and described **Minimum percentage** as the bar below which messages get flagged. StreamElements/chatbot#716 flipped that: a low-confidence reading is now **skipped**, and the setting is the confidence the detector must reach before the filter may act.

That matters because confidence spreads across 75 languages, so short messages misdetect badly. Under the old reading, an English-only channel timed out anyone typing `ok` (Zulu, 6.4%) or `gg` (Indonesian, 14.4%), at any threshold.

## What else changed on the page

- Setting names now match the dashboard: **Minimum detection confidence** and **Ignored words**, not "Minimum percentage" and "Excluded characters". The default of 40 is documented.
- Added a step-by-step "How a message is checked", covering the parts that were invisible before: ignored words are stripped case-insensitively, non-letters are dropped before detection, and a detector failure or timeout skips the filter rather than punishing.
- Added the measured confidence table from the chatbot PR, so a creator tuning the value can see where real sentences (~45% and up) sit against chat noise (below 25%), and why 40 is the default.

## Changelog

New entry at `changelog/chatbot/2026-08-17-language-filter.mdx` announcing the filter.

Verified against `bot/filters/language.go` at chatbot `v2.31.0` and the `minPercentage` default in caipirinha's `botFilters` model. Dashboard side is StreamElements/frontend#682.

`pnpm build` clean, all internal links valid.